### PR TITLE
[SH-82] 회원가입 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,11 @@ dependencies {
 	// junit
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.7.0'
+
+	// netty
+	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/snowhite/server/config/SecurityConfig.java
+++ b/src/main/java/com/snowhite/server/config/SecurityConfig.java
@@ -1,0 +1,41 @@
+package com.snowhite.server.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository;
+
+@Configuration
+@EnableWebFluxSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityWebFilterChain filterChain(ServerHttpSecurity http) {
+        http.csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
+                .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
+                .securityContextRepository(NoOpServerSecurityContextRepository.getInstance())
+                .authorizeExchange(
+                        authorize -> authorize
+                                .pathMatchers(
+                                        "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html",
+                                        "/swagger-resources/**", "/webjars/**",
+                                        "/register", "/check-email"
+                                ).permitAll()
+                                .anyExchange().authenticated()
+                );
+
+        return http.build();
+    }
+
+}

--- a/src/main/java/com/snowhite/server/domain/Card.java
+++ b/src/main/java/com/snowhite/server/domain/Card.java
@@ -1,6 +1,6 @@
-package com.snowhite.server.payload.domain;
+package com.snowhite.server.domain;
 
-import com.snowhite.server.payload.domain.common.BaseEntity;
+import com.snowhite.server.domain.common.BaseEntity;
 import jakarta.persistence.*;
 
 @Entity

--- a/src/main/java/com/snowhite/server/domain/CardType.java
+++ b/src/main/java/com/snowhite/server/domain/CardType.java
@@ -1,4 +1,4 @@
-package com.snowhite.server.payload.domain;
+package com.snowhite.server.domain;
 
 public enum CardType {
     CAVE,

--- a/src/main/java/com/snowhite/server/domain/File.java
+++ b/src/main/java/com/snowhite/server/domain/File.java
@@ -1,6 +1,6 @@
-package com.snowhite.server.payload.domain;
+package com.snowhite.server.domain;
 
-import com.snowhite.server.payload.domain.common.BaseEntity;
+import com.snowhite.server.domain.common.BaseEntity;
 import jakarta.persistence.*;
 
 @Entity

--- a/src/main/java/com/snowhite/server/domain/User.java
+++ b/src/main/java/com/snowhite/server/domain/User.java
@@ -1,8 +1,10 @@
-package com.snowhite.server.payload.domain;
+package com.snowhite.server.domain;
 
-import com.snowhite.server.payload.domain.common.BaseEntity;
+import com.snowhite.server.domain.common.BaseEntity;
 import jakarta.persistence.*;
+import lombok.Setter;
 
+@Setter
 @Entity
 @Table(name = "users")
 public class User extends BaseEntity {
@@ -21,6 +23,6 @@ public class User extends BaseEntity {
     private String password;
 
     @Column(name = "logged_in", nullable = false)
-    private boolean loggedIn;
+    private boolean loggedIn = false;
 
 }

--- a/src/main/java/com/snowhite/server/domain/UserRepository.java
+++ b/src/main/java/com/snowhite/server/domain/UserRepository.java
@@ -1,0 +1,9 @@
+package com.snowhite.server.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, String> {
+    User findByEmail(String email);
+}

--- a/src/main/java/com/snowhite/server/domain/common/BaseEntity.java
+++ b/src/main/java/com/snowhite/server/domain/common/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.snowhite.server.payload.domain.common;
+package com.snowhite.server.domain.common;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/src/main/java/com/snowhite/server/dto/EmailDto.java
+++ b/src/main/java/com/snowhite/server/dto/EmailDto.java
@@ -1,0 +1,10 @@
+package com.snowhite.server.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class EmailDto {
+    private String email;
+}

--- a/src/main/java/com/snowhite/server/dto/RegisterDto.java
+++ b/src/main/java/com/snowhite/server/dto/RegisterDto.java
@@ -1,0 +1,12 @@
+package com.snowhite.server.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class RegisterDto {
+    private String email;
+    private String username;
+    private String password;
+}

--- a/src/main/java/com/snowhite/server/payload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/snowhite/server/payload/exception/ExceptionAdvice.java
@@ -4,6 +4,8 @@ import com.snowhite.server.payload.ApiResponse;
 
 import com.snowhite.server.payload.code.status.ErrorStatus;
 import com.snowhite.server.payload.dto.ErrorReasonDTO;
+import com.snowhite.server.web.controller.HealthCheckController;
+import com.snowhite.server.web.controller.UserController;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -14,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.ServerWebExchange;
 
-@RestControllerAdvice(annotations = RestController.class)
+@RestControllerAdvice(annotations = {RestController.class}, basePackageClasses = {HealthCheckController.class, UserController.class})
 public class ExceptionAdvice {
 
     @ExceptionHandler

--- a/src/main/java/com/snowhite/server/service/UserService.java
+++ b/src/main/java/com/snowhite/server/service/UserService.java
@@ -6,6 +6,7 @@ import com.snowhite.server.payload.ApiResponse;
 import com.snowhite.server.payload.code.status.ErrorStatus;
 import com.snowhite.server.dto.EmailDto;
 import com.snowhite.server.dto.RegisterDto;
+import com.snowhite.server.payload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -21,12 +22,8 @@ public class UserService {
 
     @Transactional
     public Mono<ApiResponse<String>> register(final RegisterDto registerDto){
-        if (checkEmail(registerDto.getUsername())) {
-            return Mono.just(ApiResponse.onFailure(
-                    ErrorStatus._BAD_REQUEST.getCode(),
-                    "이미 존재하는 이메일입니다.",
-                    null
-            ));
+        if (checkEmail(registerDto.getEmail())) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
         }
         User user = new User();
         user.setEmail(registerDto.getEmail());

--- a/src/main/java/com/snowhite/server/service/UserService.java
+++ b/src/main/java/com/snowhite/server/service/UserService.java
@@ -1,0 +1,48 @@
+package com.snowhite.server.service;
+
+import com.snowhite.server.domain.User;
+import com.snowhite.server.domain.UserRepository;
+import com.snowhite.server.payload.ApiResponse;
+import com.snowhite.server.payload.code.status.ErrorStatus;
+import com.snowhite.server.dto.EmailDto;
+import com.snowhite.server.dto.RegisterDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    @Transactional
+    public Mono<ApiResponse<String>> register(final RegisterDto registerDto){
+        if (checkEmail(registerDto.getUsername())) {
+            return Mono.just(ApiResponse.onFailure(
+                    ErrorStatus._BAD_REQUEST.getCode(),
+                    "이미 존재하는 이메일입니다.",
+                    null
+            ));
+        }
+        User user = new User();
+        user.setEmail(registerDto.getEmail());
+        user.setUsername(registerDto.getUsername());
+        user.setPassword(bCryptPasswordEncoder.encode(registerDto.getPassword()));
+        userRepository.save(user);
+        return Mono.just(ApiResponse.onSuccess("회원가입이 완료되었습니다."));
+    }
+
+    public Mono<ApiResponse<String>> checkEmail(final EmailDto emailDto) {
+        boolean exists = checkEmail(emailDto.getEmail());
+        String message = exists ? "사용 중인 이메일입니다." : "사용 가능한 이메일입니다.";
+        return Mono.just(ApiResponse.onSuccess(message));
+    }
+
+    private boolean checkEmail(String email) {
+        return userRepository.findByEmail(email) != null;
+    }
+}

--- a/src/main/java/com/snowhite/server/web/controller/UserController.java
+++ b/src/main/java/com/snowhite/server/web/controller/UserController.java
@@ -1,0 +1,29 @@
+package com.snowhite.server.web.controller;
+
+import com.snowhite.server.payload.ApiResponse;
+import com.snowhite.server.dto.EmailDto;
+import com.snowhite.server.dto.RegisterDto;
+import com.snowhite.server.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/register")
+    public Mono<ApiResponse<String>> register(@RequestBody RegisterDto registerDto) {
+        return userService.register(registerDto);
+    }
+
+    @PostMapping("/check-email")
+    public Mono<ApiResponse<String>> checkEmail(@RequestBody EmailDto emailDto) {
+        return userService.checkEmail(emailDto);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Jira: [SH-82](https://snowhite.atlassian.net/browse/SH-82)

## 📝 PR 요약
사용자 회원가입 기능 구현

## ⚒️ 주요 변경 사항
- 회원가입
- 이메일 중복 확인

## 🧪 테스트 체크리스트
- [x] 회원가입
- [x] 이메일 중복 확인

## 💬 추가 사항
스웨거 적용하여 테스트하였습니다.
@ControllerAdvice 애노테이션과 Swagger 사이에 일어난 충돌이 일어나서 적용될 컨트롤러 클래스를 명시하였습니다.
mac m1에서 dns 해석 관련 네이티브 라이브러리 로드 시 에러가 발생해서 netty 의존성 추가하였습니다. 

## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?

[SH-82]: https://snowhite.atlassian.net/browse/SH-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ