### PR TITLE
[SH-12] 로그인 기능 리팩토링

### DIFF
--- a/src/main/java/com/snowhite/server/domain/entity/User.java
+++ b/src/main/java/com/snowhite/server/domain/entity/User.java
@@ -24,7 +24,4 @@ public class User extends BaseEntity {
     @Column(name = "password", nullable = false)
     private String password;
 
-    @Column(name = "logged_in", nullable = false)
-    private boolean loggedIn = false;
-
 }

--- a/src/main/java/com/snowhite/server/security/filter/JwtWebFilter.java
+++ b/src/main/java/com/snowhite/server/security/filter/JwtWebFilter.java
@@ -3,6 +3,7 @@ package com.snowhite.server.security.filter;
 import com.snowhite.server.security.jwt.JwtProvider;
 import com.snowhite.server.domain.entity.User;
 import com.snowhite.server.repository.UserRepository;
+import com.snowhite.server.security.model.CustomUserDetails;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -14,6 +15,7 @@ import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
 import reactor.core.publisher.Mono;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -41,15 +43,22 @@ public class JwtWebFilter implements WebFilter {
         if (accessToken != null && accessToken.startsWith("Bearer ")) {
             String token = accessToken.substring(7);
             if (jwtProvider.isTokenValid(token)) {
-                String userId = jwtProvider.extractClaim(token, Claims::getId);
-                Optional<User> user = userRepository.findById(Long.parseLong(userId));
-                var authentication = new UsernamePasswordAuthenticationToken(
-                        userId,
-                        null,
-                        null
-                );
-                return chain.filter(exchange)
-                        .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication));
+                String userIdStr = jwtProvider.extractClaim(token, Claims::getId);
+                Long userId = Long.parseLong(userIdStr);
+                return Mono.fromCallable(() -> userRepository.findById(userId))
+                        .flatMap(optionalUser -> {
+                            if (optionalUser.isEmpty()) {
+                                return chain.filter(exchange);
+                            }
+                            User user = optionalUser.get();
+                            CustomUserDetails customUserDetails = new CustomUserDetails(user);
+
+                            UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                                    customUserDetails,null, Collections.emptyList()
+                            );
+                            return chain.filter(exchange)
+                                    .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authenticationToken));
+                        });
             }
         }
 

--- a/src/main/java/com/snowhite/server/security/model/CustomUserDetails.java
+++ b/src/main/java/com/snowhite/server/security/model/CustomUserDetails.java
@@ -1,0 +1,38 @@
+package com.snowhite.server.security.model;
+
+import com.snowhite.server.domain.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+}

--- a/src/main/java/com/snowhite/server/service/UserService.java
+++ b/src/main/java/com/snowhite/server/service/UserService.java
@@ -33,8 +33,6 @@ public class UserService {
             throw new BadCredentialsException(ErrorStatus._BAD_REQUEST.toString());
         String accessToken = jwtProvider.generateToken(user.getId());
         LoginResponseDto.builder().token(accessToken).build();
-        user.setLoggedIn(true);
-        userRepository.save(user);
         return Mono.just(accessToken);
     }
 

--- a/src/main/java/com/snowhite/server/service/UserService.java
+++ b/src/main/java/com/snowhite/server/service/UserService.java
@@ -5,11 +5,9 @@ import com.snowhite.server.repository.UserRepository;
 import com.snowhite.server.security.jwt.JwtProvider;
 import com.snowhite.server.web.dto.web.request.LoginRequestDto;
 import com.snowhite.server.web.dto.web.response.LoginResponseDto;
-import com.snowhite.server.payload.ApiResponse;
 import com.snowhite.server.payload.code.status.ErrorStatus;
-import com.snowhite.server.web.dto.EmailDto;
+import com.snowhite.server.web.dto.web.request.EmailDto;
 import com.snowhite.server.web.dto.web.request.RegisterDto;
-import com.snowhite.server.payload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -36,17 +34,18 @@ public class UserService {
         String accessToken = jwtProvider.generateToken(user.getId());
         LoginResponseDto.builder().token(accessToken).build();
         user.setLoggedIn(true);
+        userRepository.save(user);
         return Mono.just(accessToken);
     }
 
-    public Mono<ApiResponse<String>> checkLogin(Authentication authentication, ServerHttpRequest request) {
+    public Mono<String> checkLogin(Authentication authentication, ServerHttpRequest request) {
         if (authentication == null || !authentication.isAuthenticated()) {
-            return Mono.just(ApiResponse.onSuccess("비로그인 상태"));
+            return Mono.just("비로그인 상태");
         }
         String username = authentication.getName();
         String token = resolveToken(request);
         if (token == null || !jwtProvider.isTokenValid(token)) {
-            return Mono.just(ApiResponse.onSuccess("비로그인 상태"));
+            return Mono.just("비로그인 상태");
         }
 
         Map<String, LocalDateTime> tokenTimes = jwtProvider.extractTokenTimes(token);
@@ -58,7 +57,7 @@ public class UserService {
                 tokenTimes.get("now")
         );
 
-        return Mono.just(ApiResponse.onSuccess(message));
+        return Mono.just(message);
     }
 
     private String resolveToken(ServerHttpRequest request) {
@@ -69,25 +68,23 @@ public class UserService {
         return null;
     }
 
-    public Mono<ApiResponse<String>> register(RegisterDto registerDto){
-        if (checkEmail(registerDto.getEmail())) {
-            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+    public Mono<Boolean> register(RegisterDto registerDto){
+        if (!checkEmail(registerDto.getEmail())) {
+            return Mono.just(false);
         }
         User user = new User();
         user.setEmail(registerDto.getEmail());
         user.setUsername(registerDto.getUsername());
         user.setPassword(bCryptPasswordEncoder.encode(registerDto.getPassword()));
         userRepository.save(user);
-        return Mono.just(ApiResponse.onSuccess("회원가입이 완료되었습니다."));
+        return Mono.just(true);
     }
 
-    public Mono<ApiResponse<String>> checkEmail(final EmailDto emailDto) {
-        boolean exists = checkEmail(emailDto.getEmail());
-        String message = exists ? "사용 중인 이메일입니다." : "사용 가능한 이메일입니다.";
-        return Mono.just(ApiResponse.onSuccess(message));
+    public Mono<Boolean> checkEmail(final EmailDto emailDto) {
+        return Mono.just(checkEmail(emailDto.getEmail()));
     }
 
     private boolean checkEmail(String email) {
-        return userRepository.findByEmail(email) != null;
+        return userRepository.findByEmail(email) == null;
     }
 }

--- a/src/main/java/com/snowhite/server/web/controller/UserController.java
+++ b/src/main/java/com/snowhite/server/web/controller/UserController.java
@@ -2,9 +2,12 @@ package com.snowhite.server.web.controller;
 
 import com.snowhite.server.web.dto.web.request.LoginRequestDto;
 import com.snowhite.server.payload.ApiResponse;
-import com.snowhite.server.web.dto.EmailDto;
+import com.snowhite.server.web.dto.web.request.EmailDto;
 import com.snowhite.server.web.dto.web.request.RegisterDto;
 import com.snowhite.server.service.UserService;
+import com.snowhite.server.web.dto.web.response.EmailCheckResponseDto;
+import com.snowhite.server.web.dto.web.response.LoginResponseDto;
+import com.snowhite.server.web.dto.web.response.RegisterResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -23,29 +26,53 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/login")
-    public Mono<ApiResponse<String>> login(@RequestBody LoginRequestDto loginRequestDto,
-                                           ServerWebExchange exchange) {
+    public Mono<ApiResponse<LoginResponseDto>> login(@RequestBody LoginRequestDto loginRequestDto,
+                                                     ServerWebExchange exchange) {
         ServerHttpResponse response = exchange.getResponse();
         return userService.login(loginRequestDto)
             .map(token -> {
                 response.getHeaders().add(HttpHeaders.AUTHORIZATION, "Bearer " + token);
-                return ApiResponse.onSuccess("access token: " + token);
+                return ApiResponse.onSuccess(
+                        LoginResponseDto
+                            .builder()
+                            .token(token)
+                            .build()
+                );
             });
     }
 
     @GetMapping("/check-login")
     public Mono<ApiResponse<String>> checkLogin(Authentication authentication, ServerWebExchange exchange) {
         ServerHttpRequest request = exchange.getRequest();
-        return userService.checkLogin(authentication, request);
+        return userService.checkLogin(authentication, request)
+                .map(ApiResponse::onSuccess);
     }
 
     @PostMapping("/register")
-    public Mono<ApiResponse<String>> register(@RequestBody RegisterDto registerDto) {
-        return userService.register(registerDto);
+    public Mono<ApiResponse<RegisterResponseDto>> register(@RequestBody RegisterDto registerDto) {
+        return userService.register(registerDto)
+                .map( isSuccess -> {
+                    String message = isSuccess ? "회원 가입에 성공하였습니다." : "회원 가입에 실패하였습니다. 이메일을 다시 확인해주세요.";
+                    return ApiResponse.onSuccess(
+                            RegisterResponseDto
+                                    .builder()
+                                    .isSuccess(isSuccess)
+                                    .message(message)
+                                    .build()
+                    );
+                });
     }
 
     @PostMapping("/check-email")
-    public Mono<ApiResponse<String>> checkEmail(@RequestBody EmailDto emailDto) {
-        return userService.checkEmail(emailDto);
+    public Mono<ApiResponse<EmailCheckResponseDto>> checkEmail(@RequestBody EmailDto emailDto) {
+        return userService.checkEmail(emailDto)
+            .map( isExisting -> {
+                String message = isExisting ? "사용 가능한 이메일입니다." : "사용 중인 이메일입니다.";
+                return ApiResponse.onSuccess(EmailCheckResponseDto
+                        .builder()
+                        .isExisting(isExisting)
+                        .message(message)
+                        .build());
+            });
     }
 }

--- a/src/main/java/com/snowhite/server/web/dto/web/request/EmailDto.java
+++ b/src/main/java/com/snowhite/server/web/dto/web/request/EmailDto.java
@@ -1,4 +1,4 @@
-package com.snowhite.server.web.dto;
+package com.snowhite.server.web.dto.web.request;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/snowhite/server/web/dto/web/response/EmailCheckResponseDto.java
+++ b/src/main/java/com/snowhite/server/web/dto/web/response/EmailCheckResponseDto.java
@@ -1,0 +1,11 @@
+package com.snowhite.server.web.dto.web.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EmailCheckResponseDto {
+    private Boolean isExisting;
+    private String message;
+}

--- a/src/main/java/com/snowhite/server/web/dto/web/response/RegisterResponseDto.java
+++ b/src/main/java/com/snowhite/server/web/dto/web/response/RegisterResponseDto.java
@@ -1,0 +1,11 @@
+package com.snowhite.server.web.dto.web.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RegisterResponseDto {
+    public Boolean isSuccess;
+    public String message;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,3 +31,4 @@ spring.data.redis.port=${REDIS_PORT}
 
 # JWT
 jwt.secret=${JWT_SECRET}
+server.port=8085


### PR DESCRIPTION
## 📌 관련 이슈
- Jira: [SH-83](https://snowhite.atlassian.net/browse/SH-83?atlOrigin=eyJpIjoiYTk0ZDQzMTA0OGIxNGVmMGEwMjNmYzQ0YTlhYmFhMmUiLCJwIjoiaiJ9)

## 📝 PR 요약
회원관리 리팩토링

## ⚒️ 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- HTTP 요청이 Spring Security Filter 통과 후 요청 처리중 @AuthenticationPrincipal 어노테이션을 통해 해당 User의 정보를 유지할 수 있도록 추가
- 회원관리 관련 응답 시 객체를 리턴할 수 있도록 response dto 추가 

## 🧪 테스트 체크리스트
- [x] 기존 코드 작동 여부 (회원가입, 로그인, 사용가능한 이메일, 로그인 상태)
- [x] @AuthenticationPrincipal 어노테이션으로 유저 정보를 리턴하는지 여부

## 💬 추가 사항
로그인 상태를 리턴하는 메서드는 기능 구현에 필요한 것이 아닌 테스트를 편하게 하기 위함으로써 response 객체를 따로 만들지 않고 그대로 문자열을 리턴하도록 하였습니다.

## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?

[SH-83]: https://snowhite.atlassian.net/browse/SH-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ