### PR TITLE
[SH-163] 게임 모든 정보 조회

### DIFF
--- a/src/main/java/com/snowhite/server/service/GameService.java
+++ b/src/main/java/com/snowhite/server/service/GameService.java
@@ -60,6 +60,10 @@ public class GameService {
                 });
     }
 
+    public Mono<Game> getGameByGameId(Long gameId) {
+        return reactiveRedisTemplateForGame.opsForValue().get(GAME_PREFIX + gameId);
+    }
+
     // 출발지, 목적지 카드 세팅
     public void initializeNewField(Game game) {
         game.clearField();

--- a/src/main/java/com/snowhite/server/service/GameService.java
+++ b/src/main/java/com/snowhite/server/service/GameService.java
@@ -64,6 +64,11 @@ public class GameService {
         return reactiveRedisTemplateForGame.opsForValue().get(GAME_PREFIX + gameId);
     }
 
+    public Mono<Player> findPlayerByGameIdAndPlayerId(Long gameId, Long playerId) {
+        return getGameByGameId(gameId)
+                .map(game -> game.findPlayer(playerId).get());
+    }
+
     // 출발지, 목적지 카드 세팅
     public void initializeNewField(Game game) {
         game.clearField();

--- a/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
+++ b/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
@@ -83,6 +83,12 @@ public class GameWebSocketHandler implements WebSocketHandler {
                     return handleGetGameState(session, gameId);
                 }
 
+                case "get-player-info": {
+                    long gameId = Long.parseLong(payload.get("gameId").asText());
+                    long playerId = Long.parseLong(payload.get("playerId").asText());
+                    return handleGetPlayerInfo(session, gameId, playerId);
+                }
+
                 default:
                     return sendMessage(session, "error", null);
             }
@@ -113,6 +119,12 @@ public class GameWebSocketHandler implements WebSocketHandler {
 
         return gameService.getGameByGameId(gameId)
                 .flatMap(game -> broadcastMessageToGame(gameId, "Game-State", game));
+    }
+
+    public Mono<Void> handleGetPlayerInfo(WebSocketSession session, Long gameId, Long playerId) {
+
+        return gameService.findPlayerByGameIdAndPlayerId(gameId, playerId)
+                .flatMap(player -> broadcastMessageToGame(gameId, "Player-Info", player));
     }
 
     // 게임 전체에 broadcast

--- a/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
+++ b/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
@@ -78,6 +78,11 @@ public class GameWebSocketHandler implements WebSocketHandler {
                     return handleStartRound(session, gameId);
                 }
 
+                case "get-game-state": {
+                    long gameId = Long.parseLong(payload.get("gameId").asText());
+                    return handleGetGameState(session, gameId);
+                }
+
                 default:
                     return sendMessage(session, "error", null);
             }
@@ -102,6 +107,12 @@ public class GameWebSocketHandler implements WebSocketHandler {
         return gameService.setupGameForNewRound(gameId)
                 .flatMap(game -> broadcastMessageToGame(gameId, "Round-Started", game));
 
+    }
+
+    public Mono<Void> handleGetGameState(WebSocketSession session, Long gameId) {
+
+        return gameService.getGameByGameId(gameId)
+                .flatMap(game -> broadcastMessageToGame(gameId, "Game-State", game));
     }
 
     // 게임 전체에 broadcast

--- a/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
+++ b/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
@@ -118,13 +118,13 @@ public class GameWebSocketHandler implements WebSocketHandler {
     public Mono<Void> handleGetGameState(WebSocketSession session, Long gameId) {
 
         return gameService.getGameByGameId(gameId)
-                .flatMap(game -> broadcastMessageToGame(gameId, "Game-State", game));
+                .flatMap(game -> sendMessage(session, "Game-State", game));
     }
 
     public Mono<Void> handleGetPlayerInfo(WebSocketSession session, Long gameId, Long playerId) {
 
         return gameService.findPlayerByGameIdAndPlayerId(gameId, playerId)
-                .flatMap(player -> broadcastMessageToGame(gameId, "Player-Info", player));
+                .flatMap(player -> sendMessage(session, "Player-Info", player));
     }
 
     // 게임 전체에 broadcast


### PR DESCRIPTION
## 📌 관련 이슈
- Jira: [SH-163](https://snowhite.atlassian.net/browse/SH-163?atlOrigin=eyJpIjoiNmE1YTE0Mzc5ZGYyNGIzODhmNDI1NmVlNmVhOTEwZGEiLCJwIjoiaiJ9)
- Jira: [SH-164](https://snowhite.atlassian.net/browse/SH-164?atlOrigin=eyJpIjoiMjkwMTc5MTU3ZjYzNDZhODhiZTQ3YjliYmIxMmY4NjgiLCJwIjoiaiJ9)

## 📝 PR 요약
- 163, 164 이슈 모두 포함
- 164 핸드 조회는 플레이어 정보 조회로 변경

## ⚒️ 주요 변경 사항
- get-game-state, get-player-info type 메시지 처리 추가
- GameService에 getGameByGameId, findPlayerByGameIdAndPlayerId 메소드 추가\

## 🧪 테스트 체크리스트
- [ ] 
- [ ] 

## 💬 추가 사항
- layer 분리를 위해 SocketHandler 메소드 수정 예정
- 게임 상태 조회에서 플레이어의 핸드 정보는 제외하도록 수정 예정

## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?

[SH-163]: https://snowhite.atlassian.net/browse/SH-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SH-164]: https://snowhite.atlassian.net/browse/SH-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ