### PR TITLE
[SH-90] 카드 버리기 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,10 +66,14 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// mockito
+	testImplementation 'org.mockito:mockito-inline:5.2.0'
+
 	//jackson
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+	jvmArgs += ['-XX:+EnableDynamicAgentLoading']
 }

--- a/src/main/java/com/snowhite/server/domain/session/Player.java
+++ b/src/main/java/com/snowhite/server/domain/session/Player.java
@@ -29,6 +29,8 @@ public class Player {
         cards.add(cardId);
     }
 
+    public boolean dropCard(int cardId) { return cards.remove((Integer) cardId); }
+
     public void changePlayerRole(PlayerRole playerRole) {
         this.playerRole = playerRole;
     }

--- a/src/main/java/com/snowhite/server/service/GameService.java
+++ b/src/main/java/com/snowhite/server/service/GameService.java
@@ -26,7 +26,7 @@ public class GameService {
     private final ReactiveRedisTemplate<String, Card> reactiveRedisTemplateForCard;
 
     // 카드 버리기
-    public Mono<Game> dropCard(Long gameId, Long playerId, int cardId) {
+    public Mono<Player> dropCard(Long gameId, Long playerId, int cardId) {
         String gameKey = GAME_PREFIX + gameId;
         return reactiveRedisTemplateForGame.opsForValue().get(gameKey)
                 .switchIfEmpty(Mono.error(new IllegalArgumentException("게임이 없음")))
@@ -36,12 +36,11 @@ public class GameService {
                         return Mono.error(new IllegalArgumentException("플레이어가 없음"));
                     }
                     Player player = optionalPlayer.get();
-                    List<Integer> cards = player.getCards();
-                    if (!cards.contains(cardId)) {
+                    if (!player.dropCard(cardId)) {
                         return Mono.error(new IllegalArgumentException("해당 카드가 없음"));
                     }
-                    cards.remove((Integer) cardId);
-                    return reactiveRedisTemplateForGame.opsForValue().set(gameKey, game).thenReturn(game);
+                    game.nextTurn();
+                    return reactiveRedisTemplateForGame.opsForValue().set(gameKey, game).thenReturn(player);
                 });
     }
 

--- a/src/main/java/com/snowhite/server/service/GameService.java
+++ b/src/main/java/com/snowhite/server/service/GameService.java
@@ -13,6 +13,7 @@ import reactor.core.publisher.Mono;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +24,26 @@ public class GameService {
 
     private final ReactiveRedisTemplate<String, Game> reactiveRedisTemplateForGame;
     private final ReactiveRedisTemplate<String, Card> reactiveRedisTemplateForCard;
+
+    // 카드 버리기
+    public Mono<Game> dropCard(Long gameId, Long playerId, int cardId) {
+        String gameKey = GAME_PREFIX + gameId;
+        return reactiveRedisTemplateForGame.opsForValue().get(gameKey)
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("게임이 없음")))
+                .flatMap(game -> {
+                    Optional<Player> optionalPlayer = game.findPlayer(playerId);
+                    if (optionalPlayer.isEmpty()) {
+                        return Mono.error(new IllegalArgumentException("플레이어가 없음"));
+                    }
+                    Player player = optionalPlayer.get();
+                    List<Integer> cards = player.getCards();
+                    if (!cards.contains(cardId)) {
+                        return Mono.error(new IllegalArgumentException("해당 카드가 없음"));
+                    }
+                    cards.remove((Integer) cardId);
+                    return reactiveRedisTemplateForGame.opsForValue().set(gameKey, game).thenReturn(game);
+                });
+    }
 
     // game에 player를 join시킨 후 남은 player 수 리턴
     public Mono<Integer> joinPlayer(Long gameId, Long playerId) {

--- a/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
+++ b/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
@@ -137,7 +137,7 @@ public class GameWebSocketHandler implements WebSocketHandler {
 
     public Mono<Void> handleDropCard(WebSocketSession session, Long gameId, Long playerId, Integer cardId) {
         return gameService.dropCard(gameId, playerId, cardId)
-                .flatMap(game -> sendMessage(session, "Card-Dropped", game));
+                .flatMap(player -> sendMessage(session, "Card-Dropped", player));
     }
     // 게임 전체에 broadcast
     public Mono<Void> broadcastMessageToGame(Long gameId, String type, Object payload) {

--- a/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
+++ b/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
@@ -37,6 +37,7 @@ public class GameWebSocketHandler implements WebSocketHandler {
     private final ReactiveRedisTemplate<String, Game> reactiveRedisTemplateForGame;
     private final ReactiveRedisTemplate<Long, String> reactiveRedisTemplateForSession;
 
+
     // 세션 저장 후 처리
     @Override
     public Mono<Void> handle(WebSocketSession session) {
@@ -89,6 +90,13 @@ public class GameWebSocketHandler implements WebSocketHandler {
                     return handleGetPlayerInfo(session, gameId, playerId);
                 }
 
+                case "drop-card": {
+                    long gameId = Long.parseLong(payload.get("gameId").asText());
+                    long playerId = Long.parseLong(payload.get("playerId").asText());
+                    int cardId = Integer.parseInt(payload.get("cardId").asText());
+                    return handleDropCard(session, gameId, playerId, cardId);
+                }
+
                 default:
                     return sendMessage(session, "error", null);
             }
@@ -127,6 +135,10 @@ public class GameWebSocketHandler implements WebSocketHandler {
                 .flatMap(player -> sendMessage(session, "Player-Info", player));
     }
 
+    public Mono<Void> handleDropCard(WebSocketSession session, Long gameId, Long playerId, Integer cardId) {
+        return gameService.dropCard(gameId, playerId, cardId)
+                .flatMap(game -> sendMessage(session, "Card-Dropped", game));
+    }
     // 게임 전체에 broadcast
     public Mono<Void> broadcastMessageToGame(Long gameId, String type, Object payload) {
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,4 +31,3 @@ spring.data.redis.port=${REDIS_PORT}
 
 # JWT
 jwt.secret=${JWT_SECRET}
-server.port=8085

--- a/src/test/java/com/snowhite/server/service/GameServiceTest.java
+++ b/src/test/java/com/snowhite/server/service/GameServiceTest.java
@@ -55,14 +55,11 @@ public class GameServiceTest {
         when(valueOperations.set(eq(gameKey), any(Game.class))).thenReturn(Mono.just(true));
 
         // when
-        Mono<Game> result = gameService.dropCard(gameId, playerId, cardId);
+        Mono<Player> result = gameService.dropCard(gameId, playerId, cardId);
 
         // then
         StepVerifier.create(result)
-                .expectNextMatches(updatedGame -> {
-                    Player updatedPlayer = updatedGame.findPlayer(playerId).orElseThrow();
-                    return !updatedPlayer.getCards().contains(cardId);
-                })
+                .expectNextMatches(updatedPlayer -> !updatedPlayer.getCards().contains(cardId))
                 .verifyComplete();
     }
 
@@ -77,7 +74,7 @@ public class GameServiceTest {
 
         when(valueOperations.get(eq(gameKey))).thenReturn(Mono.just(game));
 
-        Mono<Game> result = gameService.dropCard(gameId, playerId, cardId);
+        Mono<Player> result = gameService.dropCard(gameId, playerId, cardId);
 
         StepVerifier.create(result)
                 .expectErrorMatches(e -> e instanceof IllegalArgumentException &&
@@ -98,7 +95,7 @@ public class GameServiceTest {
 
         when(valueOperations.get(eq(gameKey))).thenReturn(Mono.just(game));
 
-        Mono<Game> result = gameService.dropCard(gameId, playerId, cardId);
+        Mono<Player> result = gameService.dropCard(gameId, playerId, cardId);
 
         StepVerifier.create(result)
                 .expectErrorMatches(e -> e instanceof IllegalArgumentException &&
@@ -115,7 +112,7 @@ public class GameServiceTest {
 
         when(valueOperations.get(eq(gameKey))).thenReturn(Mono.empty());
 
-        Mono<Game> result = gameService.dropCard(gameId, playerId, cardId);
+        Mono<Player> result = gameService.dropCard(gameId, playerId, cardId);
 
         StepVerifier.create(result)
                 .expectErrorMatches(e -> e instanceof IllegalArgumentException &&

--- a/src/test/java/com/snowhite/server/service/GameServiceTest.java
+++ b/src/test/java/com/snowhite/server/service/GameServiceTest.java
@@ -1,0 +1,125 @@
+package com.snowhite.server.service;
+
+import com.snowhite.server.domain.session.Game;
+import com.snowhite.server.domain.session.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.core.ReactiveValueOperations;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+public class GameServiceTest {
+
+    private GameService gameService;
+    private ReactiveRedisTemplate<String, Game> gameRedisTemplate;
+    private ReactiveValueOperations<String, Game> valueOperations;
+
+    @BeforeEach
+    void setUp() {
+        gameRedisTemplate = Mockito.mock(ReactiveRedisTemplate.class);
+        valueOperations = Mockito.mock(ReactiveValueOperations.class);
+        when(gameRedisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        gameService = new GameService(gameRedisTemplate, null);
+    }
+
+    @Test
+    void dropCard_successfully_removes_card() {
+        // given
+        Long gameId = 1L;
+        Long playerId = 100L;
+        int cardId = 42;
+        String gameKey = "game:" + gameId;
+
+        Player player = new Player(playerId, "테스터");
+        player.getCards().add(cardId);
+
+        List<Player> players = new ArrayList<>();
+        players.add(player);
+
+        Game game = new Game(gameId, players, 30);
+
+        when(valueOperations.get(eq(gameKey))).thenReturn(Mono.just(game));
+        when(valueOperations.set(eq(gameKey), any(Game.class))).thenReturn(Mono.just(true));
+
+        // when
+        Mono<Game> result = gameService.dropCard(gameId, playerId, cardId);
+
+        // then
+        StepVerifier.create(result)
+                .expectNextMatches(updatedGame -> {
+                    Player updatedPlayer = updatedGame.findPlayer(playerId).orElseThrow();
+                    return !updatedPlayer.getCards().contains(cardId);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void dropCard_fails_when_player_not_found() {
+        Long gameId = 1L;
+        Long playerId = 100L;
+        int cardId = 42;
+        String gameKey = "game:" + gameId;
+
+        Game game = new Game(gameId, new ArrayList<>(), 30);
+
+        when(valueOperations.get(eq(gameKey))).thenReturn(Mono.just(game));
+
+        Mono<Game> result = gameService.dropCard(gameId, playerId, cardId);
+
+        StepVerifier.create(result)
+                .expectErrorMatches(e -> e instanceof IllegalArgumentException &&
+                        e.getMessage().equals("플레이어가 없음"))
+                .verify();
+    }
+
+    @Test
+    void dropCard_fails_when_card_not_in_hand() {
+        Long gameId = 1L;
+        Long playerId = 100L;
+        int cardId = 42;
+        String gameKey = "game:" + gameId;
+
+        Player player = new Player(playerId, "테스터");
+
+        Game game = new Game(gameId, List.of(player), 30);
+
+        when(valueOperations.get(eq(gameKey))).thenReturn(Mono.just(game));
+
+        Mono<Game> result = gameService.dropCard(gameId, playerId, cardId);
+
+        StepVerifier.create(result)
+                .expectErrorMatches(e -> e instanceof IllegalArgumentException &&
+                        e.getMessage().equals("해당 카드가 없음"))
+                .verify();
+    }
+
+    @Test
+    void dropCard_fails_when_game_not_found() {
+        Long gameId = 1L;
+        Long playerId = 100L;
+        int cardId = 42;
+        String gameKey = "game:" + gameId;
+
+        when(valueOperations.get(eq(gameKey))).thenReturn(Mono.empty());
+
+        Mono<Game> result = gameService.dropCard(gameId, playerId, cardId);
+
+        StepVerifier.create(result)
+                .expectErrorMatches(e -> e instanceof IllegalArgumentException &&
+                        e.getMessage().equals("게임이 없음"))
+                .verify();
+    }
+}

--- a/src/test/java/com/snowhite/server/service/RoomWebSocketHandlerTest.java
+++ b/src/test/java/com/snowhite/server/service/RoomWebSocketHandlerTest.java
@@ -81,7 +81,6 @@ class RoomWebSocketHandlerTest {
         testUser.setUsername("testuser");
         testUser.setPassword(passwordEncoder.encode("password"));
         testUser.setEmail("testuser@test.com");
-        testUser.setLoggedIn(true);
         testUser = userRepository.save(testUser);
 
         jwtToken = jwtProvider.generateToken(testUser.getId());
@@ -127,7 +126,6 @@ class RoomWebSocketHandlerTest {
                                     Assertions.assertEquals(testUser.getId(), masterPlayerNode.get("id").asLong());
                                     Assertions.assertEquals(testUser.getUsername(), masterPlayerNode.get("username").asText());
                                     Assertions.assertEquals(testUser.getEmail(), masterPlayerNode.get("email").asText());
-                                    Assertions.assertEquals(testUser.isLoggedIn(), masterPlayerNode.get("loggedIn").asBoolean());
 
                                     session.close()
                                             .subscribe();
@@ -152,7 +150,6 @@ class RoomWebSocketHandlerTest {
         joinUser.setUsername("joinUser");
         joinUser.setEmail("joinUser@example.com");
         joinUser.setPassword("password");
-        joinUser.setLoggedIn(true);
 
         userRepository.save(joinUser);
 


### PR DESCRIPTION
<!-- PR제목 예시: [SH-12] 로그인 기능 구현 -->
## 📌 관련 이슈
- Jira: [SH-90](https://snowhite.atlassian.net/browse/SH-90?atlOrigin=eyJpIjoiNjlmYzk1MjQ4ZThjNGZlZjkzNjlhNzE3ZjQ5OTliMDciLCJwIjoiaiJ9)

## 📝 PR 요약
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
플레이어가 카드를 한장 버리는 기능을 구현했습니다

## ⚒️ 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- 게임아이디, 플레이어아이디, 카드아이디가 주어졌을 때, 게임, 플레이어가 존재하고 플레이어가 해당 카드를 가지고 있다면 카드를 버리고 게임에 카드를 버렸다는 것을 알립니다.

## 🧪 테스트 체크리스트
- [x] 게임아이디, 플레이어아이디, 카드아이디가 주어졌을 때 하나라도 없으면 예외처리를 하는가
- [x] 제대로 카드를 버리는가

## 💬 추가 사항
GameServiceTest에서 JUnit 테스트로 진행했습니다.
유저 필드 중 로그인 상태인지 확인하는 필드가 삭제되었는데 RoomWebSocketHandlerTest에 반영되지 않아서 그부분만 제거했습니다.

## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?

[SH-90]: https://snowhite.atlassian.net/browse/SH-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ