### PR TITLE
[FIX] Card Table 초기화 오류 수정

### DIFF
--- a/src/main/java/com/snowhite/server/init/CardInitializer.java
+++ b/src/main/java/com/snowhite/server/init/CardInitializer.java
@@ -9,6 +9,7 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
 
@@ -88,7 +89,7 @@ public class CardInitializer {
                 new Card(111, "broken - minecart", CardType.ACTION)
         );
 
-        cardRepository.deleteAll();
+        cardRepository.deleteAllInBatch();
         cardRepository.saveAll(cardList);
         cardRepository.findAll().forEach(card -> {
             reactiveRedisTemplateForCard.opsForValue()


### PR DESCRIPTION
## 📝 PR 요약
- Card Table 초기화하는 과정에서 발생하는 오류 수정

## ⚒️ 주요 변경 사항
- card table을 비울 때 deleteAll() 대신 deleteAllInBatch() 사용

## 🧪 테스트 체크리스트
- [ ] 
- [ ] 

## 💬 추가 사항


## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?