### PR TITLE
[FEAT] 세션 prefix 분리

### DIFF
--- a/src/main/java/com/snowhite/server/config/RedisConfig.java
+++ b/src/main/java/com/snowhite/server/config/RedisConfig.java
@@ -32,7 +32,7 @@ public class RedisConfig {
         return new LettuceConnectionFactory(host, port);
     }
 
-    @Bean(name="reactiveRedisTemplateForRooms")
+    @Bean
     public ReactiveRedisTemplate<String, Room> reactiveRedisTemplateForRooms(
             ReactiveRedisConnectionFactory factory,
             ObjectMapper objectMapper) {
@@ -50,13 +50,25 @@ public class RedisConfig {
         return new ReactiveRedisTemplate<>(factory, context);
     }
 
-    @Bean(name="reactiveRedisTemplateForSessionIds")
+    @Bean
     public ReactiveRedisTemplate<Long, String> reactiveRedisTemplateForSession(
             ReactiveRedisConnectionFactory factory) {
         RedisSerializationContext<Long, String> context = RedisSerializationContext
                 .<Long, String> newSerializationContext(new GenericToStringSerializer<>(Long.class))
                 .value(new StringRedisSerializer())
                 .build();
+        return new ReactiveRedisTemplate<>(factory, context);
+    }
+
+    @Bean
+    public ReactiveRedisTemplate<String, String> reactiveRedisTemplateForSessionIds(
+            ReactiveRedisConnectionFactory factory) {
+
+        RedisSerializationContext<String, String> context = RedisSerializationContext
+                .<String, String>newSerializationContext(new StringRedisSerializer())
+                .value(new StringRedisSerializer())
+                .build();
+
         return new ReactiveRedisTemplate<>(factory, context);
     }
 

--- a/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
+++ b/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class GameWebSocketHandler implements WebSocketHandler {
 
     private static final String GAME_PREFIX = "game:";
+    private static final String GAME_SESSION_PREFIX = "game-session:";
 
     private final CardRepository cardRepository;
     private final GameService gameService;
@@ -41,7 +42,7 @@ public class GameWebSocketHandler implements WebSocketHandler {
     private final ConcurrentHashMap<String, WebSocketSession> sessionMap = new ConcurrentHashMap<>();
 
     private final ReactiveRedisTemplate<String, Game> reactiveRedisTemplateForGame;
-    private final ReactiveRedisTemplate<Long, String> reactiveRedisTemplateForSession;
+    private final ReactiveRedisTemplate<String, String> reactiveRedisTemplateForSessionIds;
 
 
     // 세션 저장 후 처리
@@ -52,12 +53,12 @@ public class GameWebSocketHandler implements WebSocketHandler {
         String token = jwtProvider.extractTokenFromURI(uri);
         Long userId = jwtProvider.extractUserIdFromToken(token);
 
-        return reactiveRedisTemplateForSession.opsForValue().set(userId, session.getId())
+        return reactiveRedisTemplateForSessionIds.opsForValue().set(GAME_SESSION_PREFIX + userId, session.getId())
                 .doOnSuccess(ignored -> sessionMap.put(session.getId(), session))
                 .then(session.receive()
                         .doFinally(signalType -> {
                             sessionMap.remove(session.getId());
-                            reactiveRedisTemplateForSession.delete(userId).subscribe();
+                            reactiveRedisTemplateForSessionIds.delete(GAME_SESSION_PREFIX + userId).subscribe();
                         })
                         .map(WebSocketMessage::getPayloadAsText)
                         .flatMap(message -> handleMessage(session, message, userId))
@@ -212,7 +213,7 @@ public class GameWebSocketHandler implements WebSocketHandler {
                 .flatMapMany(game -> Flux.fromIterable(game.getPlayers()))
                 .flatMap(player -> {
                     Long playerId = player.getPlayerId();
-                    return reactiveRedisTemplateForSession.opsForValue().get(playerId)
+                    return reactiveRedisTemplateForSessionIds.opsForValue().get(playerId)
                             .flatMap(sessionId -> {
                                 WebSocketSession sessionToSend = sessionMap.get(sessionId);
                                 return sendMessage(sessionToSend, type, payload);

--- a/src/main/java/com/snowhite/server/websocket/handler/RoomWebSocketHandler.java
+++ b/src/main/java/com/snowhite/server/websocket/handler/RoomWebSocketHandler.java
@@ -10,6 +10,7 @@ import com.snowhite.server.repository.UserRepository;
 import com.snowhite.server.security.jwt.JwtProvider;
 import com.snowhite.server.service.RoomService;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.reactivestreams.Publisher;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -31,12 +32,13 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class RoomWebSocketHandler implements WebSocketHandler {
 
     private static final AtomicLong roomIdGenerator = new AtomicLong(0);
 
-    private final ReactiveRedisTemplate<String, Room> redisTemplateForRooms;
-    private final ReactiveRedisTemplate<Long, String> redisTemplateForSessionIds;
+    private final ReactiveRedisTemplate<String, Room> reactiveRedisTemplateForRooms;
+    private final ReactiveRedisTemplate<String, String> reactiveRedisTemplateForSessionIds;
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
     private final ObjectMapper objectMapper;
@@ -46,24 +48,7 @@ public class RoomWebSocketHandler implements WebSocketHandler {
     private final ConcurrentHashMap<String, WebSocketSession> sessionMap = new ConcurrentHashMap<>();
 
     private static final String ROOM_PREFIX = "room:";
-
-    public RoomWebSocketHandler(
-            @Qualifier("reactiveRedisTemplateForRooms")
-            ReactiveRedisTemplate<String, Room> redisTemplateForRooms,
-            @Qualifier("reactiveRedisTemplateForSessionIds")
-            ReactiveRedisTemplate<Long, String> redisTemplateForSessionIds,
-            UserRepository userRepository,
-            JwtProvider jwtProvider,
-            ObjectMapper objectMapper,
-            RoomService roomService
-    ) {
-        this.redisTemplateForRooms = redisTemplateForRooms;
-        this.redisTemplateForSessionIds = redisTemplateForSessionIds;
-        this.userRepository = userRepository;
-        this.jwtProvider = jwtProvider;
-        this.objectMapper = objectMapper;
-        this.roomService = roomService;
-    }
+    private static final String ROOM_SESSION_PREFIX = "room_session:";
 
     @Override
     @NonNull
@@ -88,7 +73,7 @@ public class RoomWebSocketHandler implements WebSocketHandler {
 
         long userId = jwtProvider.extractUserIdFromToken(token);
 
-        return redisTemplateForSessionIds.opsForValue().set(userId, session.getId())
+        return reactiveRedisTemplateForSessionIds.opsForValue().set(ROOM_SESSION_PREFIX + userId, session.getId())
                 .doOnSuccess(ignored -> sessionMap.put(session.getId(), session))
                 .then(
                         session.receive()
@@ -171,7 +156,7 @@ public class RoomWebSocketHandler implements WebSocketHandler {
 
                     Room room = new Room(roomId, roomName, user, users, capacity, turnTime, false);
 
-                    Mono<Boolean> saveRoom = redisTemplateForRooms.
+                    Mono<Boolean> saveRoom = reactiveRedisTemplateForRooms.
                             opsForValue().set(ROOM_PREFIX + String.valueOf(roomId), room);
 
                     return Mono.when(saveRoom)
@@ -189,7 +174,7 @@ public class RoomWebSocketHandler implements WebSocketHandler {
 
                     User user = optionalUser.get();
 
-                    return redisTemplateForRooms.opsForValue().get(ROOM_PREFIX + String.valueOf(roomId))
+                    return reactiveRedisTemplateForRooms.opsForValue().get(ROOM_PREFIX + String.valueOf(roomId))
                             .flatMap(room -> {
                                 if (room == null) {
                                     return sendMessage(session, "error", "Room not found");
@@ -203,9 +188,9 @@ public class RoomWebSocketHandler implements WebSocketHandler {
                                 users.add(user);
                                 room.setUsers(users);
 
-                                return redisTemplateForRooms.opsForValue()
+                                return reactiveRedisTemplateForRooms.opsForValue()
                                         .set(ROOM_PREFIX + String.valueOf(roomId), room)
-                                        .then(redisTemplateForSessionIds.opsForValue().set(userId, session.getId()))
+                                        .then(reactiveRedisTemplateForSessionIds.opsForValue().set(ROOM_SESSION_PREFIX + userId, session.getId()))
                                         .then(broadcastToRoom(userId, room))
                                         .and(sendMessage(session, "joined-room", room));
                             });
@@ -222,7 +207,7 @@ public class RoomWebSocketHandler implements WebSocketHandler {
 
                     User user = optionalUser.get();
 
-                    return redisTemplateForRooms.opsForValue().get(ROOM_PREFIX + String.valueOf(roomId))
+                    return reactiveRedisTemplateForRooms.opsForValue().get(ROOM_PREFIX + String.valueOf(roomId))
                             .flatMap(room -> {
                                 if (room == null) {
                                     return sendMessage(session, "error", "Room not found");
@@ -251,15 +236,15 @@ public class RoomWebSocketHandler implements WebSocketHandler {
                                 Mono<Boolean> roomQuit;
 
                                 if (isMasterPlayer && users.isEmpty()) {
-                                    roomQuit = redisTemplateForRooms
+                                    roomQuit = reactiveRedisTemplateForRooms
                                             .delete(ROOM_PREFIX + String.valueOf(roomId)).thenReturn(Boolean.TRUE);
                                 } else {
-                                    roomQuit = redisTemplateForRooms.opsForValue()
+                                    roomQuit = reactiveRedisTemplateForRooms.opsForValue()
                                             .set(ROOM_PREFIX + String.valueOf(roomId), room);
                                 }
 
                                 return roomQuit
-                                        .then(redisTemplateForSessionIds.delete(userId))
+                                        .then(reactiveRedisTemplateForSessionIds.delete(ROOM_SESSION_PREFIX + userId))
                                         .then(
                                                 isMasterPlayer && users.isEmpty() ?
                                                         sendMessage(session, "quit-success", null) :
@@ -277,7 +262,7 @@ public class RoomWebSocketHandler implements WebSocketHandler {
 
         List<Mono<Void>> broadcasts = room.getUsers().stream()
                 .filter(user -> user.getId() != userId)
-                .map(user -> redisTemplateForSessionIds.opsForValue().get(user.getId())
+                .map(user -> reactiveRedisTemplateForSessionIds.opsForValue().get(ROOM_SESSION_PREFIX + user.getId())
                         .flatMap(sessionId -> {
                             WebSocketSession userSession = sessionMap.get(sessionId);
                             if (userSession != null && userSession.isOpen()) {
@@ -312,7 +297,7 @@ public class RoomWebSocketHandler implements WebSocketHandler {
                 .flatMapMany(room -> Flux.fromIterable(room.getUsers()))
                 .flatMap(user -> {
                     Long userId = user.getId();
-                    return redisTemplateForSessionIds.opsForValue().get(userId)
+                    return reactiveRedisTemplateForSessionIds.opsForValue().get(ROOM_SESSION_PREFIX + userId)
                             .flatMap(sessionId -> {
                                 WebSocketSession sessionToSend = sessionMap.get(sessionId);
                                 return sendMessage(sessionToSend, type, payload);


### PR DESCRIPTION
## 📝 PR 요약
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
- 세션 prefix room, game 분리
## ⚒️ 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- userId 하나로 유지하던 session을 웹소켓 동시 사용을 위해 room_session:userId, game_session:userId로 분리

## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?