### PR TITLE
[Fix] prefix 분리에 따른 행동카드 handler 수정

### DIFF
--- a/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
+++ b/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
@@ -27,7 +27,6 @@ import reactor.core.publisher.Mono;
 import org.slf4j.Logger;
 
 import java.time.Duration;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Component
@@ -67,10 +66,6 @@ public class GameWebSocketHandler implements WebSocketHandler {
                 );
     }
 
-    public Map<String, WebSocketSession> getSessionMap() {
-        return sessionMap;
-    }
-
     // type에 따라 요청 처리
     public Mono<Void> handleMessage(WebSocketSession session, String message, Long playerId) {
         try {
@@ -101,7 +96,7 @@ public class GameWebSocketHandler implements WebSocketHandler {
                 case "use-rockfall-card" : {
                     RockfallCardUseRequest request = new RockfallCardUseRequest(
                             payload.get("gameId").asLong(),
-                            payload.get("playerId").asLong(),
+                            playerId,
                             payload.get("cardId").asInt(),
                             payload.get("row").asInt(),
                             payload.get("column").asInt()
@@ -111,7 +106,7 @@ public class GameWebSocketHandler implements WebSocketHandler {
                 case "use-map-card" : {
                     MapCardUseRequest request = new MapCardUseRequest(
                             payload.get("gameId").asLong(),
-                            payload.get("playerId").asLong(),
+                            playerId,
                             payload.get("cardId").asInt(),
                             payload.get("row").asInt(),
                             payload.get("column").asInt()
@@ -121,7 +116,7 @@ public class GameWebSocketHandler implements WebSocketHandler {
                 case "use-repair-card" : {
                     RepairCardUseRequest request = new RepairCardUseRequest(
                             payload.get("gameId").asLong(),
-                            payload.get("playerId").asLong(),
+                            playerId,
                             payload.get("targetPlayerId").asLong(),
                             payload.get("cardId").asInt(),
                             objectMapper.treeToValue(payload.get("targetState"), PlayerState.class)
@@ -131,7 +126,7 @@ public class GameWebSocketHandler implements WebSocketHandler {
                 case "use-broken-card" : {
                     BrokenCardUseRequest request = new BrokenCardUseRequest(
                             payload.get("gameId").asLong(),
-                            payload.get("playerId").asLong(),
+                            playerId,
                             payload.get("targetPlayerId").asLong(),
                             payload.get("cardId").asInt()
                     );


### PR DESCRIPTION
## 📌 관련 이슈
- Jira: [SH-89]

## 📝 PR 요약
prefix 분리에 따라 handler에 넘겨준 playerId 사용하는걸로 변경

## ⚒️ 주요 변경 사항
- 행동카드에 대해 handler에서 playerId를 client에서 요청받지 않도록 수정

## 🧪 테스트 체크리스트
- [로컬 테스트]

## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?

[SH-89]: https://snowhite.atlassian.net/browse/SH-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ