### PR TITLE
[SH-182] 행동 카드 사용 후 턴 변경 및 라운드 종료 검사 및 지도 카드 사용 후 응답에 목적지 카드 id 추가

### DIFF
--- a/src/main/java/com/snowhite/server/service/GameService.java
+++ b/src/main/java/com/snowhite/server/service/GameService.java
@@ -315,11 +315,12 @@ public class GameService {
                         try {
                             Player player = findPlayerByPlayerId(game, playerId);
                             log.info("[Map] 플레이어 조회 성공 - playerId: {}", playerId);
-                            
-                            if (game.getDestCardIdAt(row, column) == -1) {
+                            int destCarId = game.getDestCardIdAt(row, column);
+                            if (destCarId == -1) {
                                 log.warn("[Map] 해당 위치에 카드가 없거나 사용 불가한 위치 - row: {}, column: {}", row, column);
                                 return Mono.error(new BusinessException(WsErrorStatus.BAD_REQUEST));
                             }
+                            // TODO: field 변경에 따른 isFlipped 인덱싱 수정
                             if (game.isFlipped(row, column)) {
                                 log.warn("[Map] 해당 위치에 카드가 이미 공개됨 - row: {}, column: {}", row, column);
                                 return Mono.error(new BusinessException(WsErrorStatus.CANNOT_USE_CARD));
@@ -358,7 +359,8 @@ public class GameService {
                                         .thenReturn(UseMapCardResultDTO.forNormalResult(
                                                 TurnChangedResponse.of(game.getCurrentTurnPlayerId()),
                                                 secretPlayerResponse,
-                                                publicPlayerResponse
+                                                publicPlayerResponse,
+                                                destCarId
                                         ));
                             }
                         } catch (BusinessException e) {

--- a/src/main/java/com/snowhite/server/service/GameService.java
+++ b/src/main/java/com/snowhite/server/service/GameService.java
@@ -249,28 +249,43 @@ public class GameService {
                         game.drawAndGiveCardToPlayer(playerId);
                         log.info("[Rockfall] 카드 한장 가져오기");
 
-                        return saveGameToRedis(game)
-                                .flatMap(success -> {
-                                    if (success) {
-                                        SecretPlayerResponse secretPlayerResponse = SecretPlayerResponse.from(game.findPlayer(playerId).get());
-                                        PublicPlayerResponse publicPlayerResponse = PublicPlayerResponse.from(game.findPlayer(playerId).get());
-                                        FieldResponse fieldResponse = FieldResponse.of(-1, row, column, game.getField()[row][column][1]);
-                                        TurnChangedResponse turnChangedResponse = TurnChangedResponse.of(game.getCurrentTurnPlayerId());
-                                        UseRockfallCardResultDTO response = new UseRockfallCardResultDTO(
-                                                turnChangedResponse,
-                                                secretPlayerResponse,
-                                                publicPlayerResponse,
-                                                fieldResponse
-                                        );
+                        FieldResponse fieldResponse = FieldResponse.of(-1, row, column, game.getField()[row][column][1]);
+                        SecretPlayerResponse secretPlayerResponse = SecretPlayerResponse.from(game.findPlayer(playerId).get());
+                        PublicPlayerResponse publicPlayerResponse = PublicPlayerResponse.from(game.findPlayer(playerId).get());
 
-                                        log.info("[Rockfall] 카드 사용 완료 - 응답 생성");
-                                        return Mono.just(response);
-                                    } else {
-                                        log.error("[Rockfall] 게임 Redis 저장 실패");
-                                        return Mono.error(new BusinessException(WsErrorStatus.INTERNAL_ERROR));
-                                    }
-                                });
-                    })
+                        boolean isRoundFinished = false;
+                        if (game.nextTurnAndReturnRoundFinished()) {
+                            isRoundFinished = true;
+                        }
+                        if(isRoundFinished) {
+                            // 라운드 종료되면 RoundFinishedResponse 반환
+                            // 사보타지가 이긴 경우만 존재
+                            Map<Long, Integer> distributedGoldInfo = game.distributeGoldToSaboteur();
+                            List<RoundFinishedPlayerDTO> playerList = distributedGoldInfo.entrySet().stream()
+                                    .map(entry -> {
+                                        long id = entry.getKey();
+                                        int gainedGold = entry.getValue();
+                                        return RoundFinishedPlayerDTO.of(id, player.getPlayerName(), player.getPlayerRole(), gainedGold);
+                                    }).toList();
+                            return setGameToRedis(gameId, game)
+                                    .thenReturn(UseRockfallCardResultDTO.forRoundFinishedResult(
+                                            RoundFinishedResponse.of(PlayerRole.SABOTEUR, playerList),
+                                            secretPlayerResponse,
+                                            publicPlayerResponse,
+                                            fieldResponse
+                                    ));
+                        } else {
+                            // 라운드가 종료되지 않으면 TurnChangedResonse 반환
+                            return setGameToRedis(gameId, game)
+                                    .thenReturn(UseRockfallCardResultDTO.forNormalResult(
+                                            TurnChangedResponse.of(game.getCurrentTurnPlayerId()),
+                                            secretPlayerResponse,
+                                            publicPlayerResponse,
+                                            fieldResponse
+                                    ));
+                        }
+                            }
+                        )
                     .onErrorResume(e -> {
                         log.error("[Rockfall] 예외 발생: {}", e.getMessage(), e);
                         return Mono.error(e);

--- a/src/main/java/com/snowhite/server/service/GameService.java
+++ b/src/main/java/com/snowhite/server/service/GameService.java
@@ -349,7 +349,7 @@ public class GameService {
                                                 RoundFinishedResponse.of(PlayerRole.SABOTEUR, playerList),
                                                 secretPlayerResponse,
                                                 publicPlayerResponse,
-                                                destCarId,
+                                                CardIdResponse.of(destCarId),
                                                 true
                                         ));
                             } else {
@@ -359,7 +359,7 @@ public class GameService {
                                                 TurnChangedResponse.of(game.getCurrentTurnPlayerId()),
                                                 secretPlayerResponse,
                                                 publicPlayerResponse,
-                                                destCarId
+                                                CardIdResponse.of(destCarId)
                                         ));
                             }
                         } catch (BusinessException e) {

--- a/src/main/java/com/snowhite/server/service/GameService.java
+++ b/src/main/java/com/snowhite/server/service/GameService.java
@@ -197,11 +197,6 @@ public class GameService {
                 .switchIfEmpty(Mono.error(new BusinessException(WsErrorStatus.BAD_REQUEST)));
     }
 
-    private Mono<Boolean> saveGameToRedis(Game game) {
-        return reactiveRedisTemplateForGame.opsForValue()
-                .set(GAME_PREFIX + game.getGameId(), game);
-    }
-
     private List<PlayerState> getRepairStates(ActionCardType type) {
         return switch (type) {
             case REPAIR_PICKAXE -> List.of(PlayerState.BROKEN_PICKAXE);

--- a/src/main/java/com/snowhite/server/service/GameService.java
+++ b/src/main/java/com/snowhite/server/service/GameService.java
@@ -329,30 +329,38 @@ public class GameService {
                             game.drawAndGiveCardToPlayer(playerId);
                             log.info("[Map] 카드 한장 가져오기");
 
-                            return saveGameToRedis(game)
-                                    .flatMap(success -> {
-                                        if (success) {
-                                            SecretPlayerResponse secretPlayerResponse = SecretPlayerResponse.from(game.findPlayer(playerId).get());
-                                            PublicPlayerResponse publicPlayerResponse = PublicPlayerResponse.from(game.findPlayer(playerId).get());
-                                            TurnChangedResponse turnChangedResponse = TurnChangedResponse.of(game.getCurrentTurnPlayerId());
-                                            UseMapCardResultDTO response = new UseMapCardResultDTO(
-                                                    turnChangedResponse,
-                                                    secretPlayerResponse,
-                                                    publicPlayerResponse
-                                            );
-                                            log.info("[Map] 카드 사용 완료 - 응답 생성");
-                                            return Mono.just(response);
-                                        } else {
-                                            return Mono.error(new BusinessException(WsErrorStatus.INTERNAL_ERROR));
-                                        }
-                                    })
-                                    .onErrorResume(e -> {
-                                        // saveGameToRedis 에서 발생한 예외
-                                        if (e instanceof BusinessException) return Mono.error(e);
-                                        log.error("[Map] 게임 Redis 저장 실패");
-                                        return Mono.error(new WebSocketException(WsErrorStatus.INTERNAL_ERROR.getErrorReason()));
-                                    });
+                            SecretPlayerResponse secretPlayerResponse = SecretPlayerResponse.from(game.findPlayer(playerId).get());
+                            PublicPlayerResponse publicPlayerResponse = PublicPlayerResponse.from(game.findPlayer(playerId).get());
 
+                            boolean isRoundFinished = false;
+                            if (game.nextTurnAndReturnRoundFinished()) {
+                                isRoundFinished = true;
+                            }
+                            if(isRoundFinished) {
+                                // 라운드 종료되면 RoundFinishedResponse 반환
+                                // 사보타지가 이긴 경우만 존재
+                                Map<Long, Integer> distributedGoldInfo = game.distributeGoldToSaboteur();
+                                List<RoundFinishedPlayerDTO> playerList = distributedGoldInfo.entrySet().stream()
+                                        .map(entry -> {
+                                            long id = entry.getKey();
+                                            int gainedGold = entry.getValue();
+                                            return RoundFinishedPlayerDTO.of(id, player.getPlayerName(), player.getPlayerRole(), gainedGold);
+                                        }).toList();
+                                return setGameToRedis(gameId, game)
+                                        .thenReturn(UseMapCardResultDTO.forRoundFinishedResult(
+                                                RoundFinishedResponse.of(PlayerRole.SABOTEUR, playerList),
+                                                secretPlayerResponse,
+                                                publicPlayerResponse
+                                        ));
+                            } else {
+                                // 라운드가 종료되지 않으면 TurnChangedResonse 반환
+                                return setGameToRedis(gameId, game)
+                                        .thenReturn(UseMapCardResultDTO.forNormalResult(
+                                                TurnChangedResponse.of(game.getCurrentTurnPlayerId()),
+                                                secretPlayerResponse,
+                                                publicPlayerResponse
+                                        ));
+                            }
                         } catch (BusinessException e) {
                             return Mono.error(e);
                         } catch (Exception e) {

--- a/src/main/java/com/snowhite/server/service/GameService.java
+++ b/src/main/java/com/snowhite/server/service/GameService.java
@@ -609,32 +609,41 @@ public class GameService {
                                         game.drawAndGiveCardToPlayer(playerId);
                                         log.info("[Repair] 카드 한장 가져오기");
 
-                                        return saveGameToRedis(game)
-                                                .flatMap(success -> {
-                                                    if (success) {
-                                                        log.info("[Repair] Redis 저장 완료");
-                                                        SecretPlayerResponse secretPlayerResponse = SecretPlayerResponse.from(game.findPlayer(playerId).get());
-                                                        PublicPlayerResponse publicPlayerResponse = PublicPlayerResponse.from(game.findPlayer(playerId).get());
-                                                        PublicPlayerResponse publicTargetPlayerResponse = PublicPlayerResponse.from(game.findPlayer(targetPlayerId).get());
-                                                        TurnChangedResponse turnChangedResponse = TurnChangedResponse.of(game.getCurrentTurnPlayerId());
-                                                        UseRepairCardDTO response = new UseRepairCardDTO(
-                                                                turnChangedResponse,
-                                                                secretPlayerResponse,
-                                                                publicPlayerResponse,
-                                                                publicTargetPlayerResponse
-                                                        );
-                                                        return Mono.just(response);
-                                                    } else {
-                                                        log.error("[Repair] Redis 저장 실패");
-                                                        return Mono.error(new BusinessException(WsErrorStatus.INTERNAL_ERROR));
-                                                    }
-                                                })
-                                                .onErrorResume(e -> {
-                                                    if (e instanceof BusinessException) return Mono.error(e);
-                                                    log.error("[Repair] Redis 저장 중 예외 발생", e);
-                                                    return Mono.error(new WebSocketException(WsErrorStatus.INTERNAL_ERROR.getErrorReason()));
-                                                });
+                                        SecretPlayerResponse secretPlayerResponse = SecretPlayerResponse.from(game.findPlayer(playerId).get());
+                                        PublicPlayerResponse publicPlayerResponse = PublicPlayerResponse.from(game.findPlayer(playerId).get());
+                                        PublicPlayerResponse publicTargetPlayerResponse = PublicPlayerResponse.from(game.findPlayer(targetPlayerId).get());
 
+                                        boolean isRoundFinished = false;
+                                        if (game.nextTurnAndReturnRoundFinished()) {
+                                            isRoundFinished = true;
+                                        }
+                                        if(isRoundFinished) {
+                                            // 라운드 종료되면 RoundFinishedResponse 반환
+                                            // 사보타지가 이긴 경우만 존재
+                                            Map<Long, Integer> distributedGoldInfo = game.distributeGoldToSaboteur();
+                                            List<RoundFinishedPlayerDTO> playerList = distributedGoldInfo.entrySet().stream()
+                                                    .map(entry -> {
+                                                        long id = entry.getKey();
+                                                        int gainedGold = entry.getValue();
+                                                        return RoundFinishedPlayerDTO.of(id, player.getPlayerName(), player.getPlayerRole(), gainedGold);
+                                                    }).toList();
+                                            return setGameToRedis(gameId, game)
+                                                    .thenReturn(UseRepairCardDTO.forRoundFinishedResult(
+                                                            RoundFinishedResponse.of(PlayerRole.SABOTEUR, playerList),
+                                                            secretPlayerResponse,
+                                                            publicPlayerResponse,
+                                                            publicTargetPlayerResponse
+                                                    ));
+                                        } else {
+                                            // 라운드가 종료되지 않으면 TurnChangedResonse 반환
+                                            return setGameToRedis(gameId, game)
+                                                    .thenReturn(UseRepairCardDTO.forNormalResult(
+                                                            TurnChangedResponse.of(game.getCurrentTurnPlayerId()),
+                                                            secretPlayerResponse,
+                                                            publicPlayerResponse,
+                                                            publicTargetPlayerResponse
+                                                    ));
+                                        }
                                     } catch (Exception e) {
                                         log.error("[Repair] 카드 처리 중 예외 발생", e);
                                         return Mono.error(new WebSocketException(WsErrorStatus.INTERNAL_ERROR.getErrorReason()));

--- a/src/main/java/com/snowhite/server/service/GameService.java
+++ b/src/main/java/com/snowhite/server/service/GameService.java
@@ -564,7 +564,7 @@ public class GameService {
                 });
     }
 
-    public Mono<UseRepairCardDTO> useRepairCard(RepairCardUseRequest request) {
+    public Mono<UseRepairCardResultDTO> useRepairCard(RepairCardUseRequest request) {
         Long gameId = request.gameId();
         Long playerId = request.playerId();
         int cardId = request.cardId();
@@ -628,7 +628,7 @@ public class GameService {
                                                         return RoundFinishedPlayerDTO.of(id, player.getPlayerName(), player.getPlayerRole(), gainedGold);
                                                     }).toList();
                                             return setGameToRedis(gameId, game)
-                                                    .thenReturn(UseRepairCardDTO.forRoundFinishedResult(
+                                                    .thenReturn(UseRepairCardResultDTO.forRoundFinishedResult(
                                                             RoundFinishedResponse.of(PlayerRole.SABOTEUR, playerList),
                                                             secretPlayerResponse,
                                                             publicPlayerResponse,
@@ -637,7 +637,7 @@ public class GameService {
                                         } else {
                                             // 라운드가 종료되지 않으면 TurnChangedResonse 반환
                                             return setGameToRedis(gameId, game)
-                                                    .thenReturn(UseRepairCardDTO.forNormalResult(
+                                                    .thenReturn(UseRepairCardResultDTO.forNormalResult(
                                                             TurnChangedResponse.of(game.getCurrentTurnPlayerId()),
                                                             secretPlayerResponse,
                                                             publicPlayerResponse,
@@ -708,43 +708,41 @@ public class GameService {
                                         game.drawAndGiveCardToPlayer(playerId);
                                         log.info("[Broken] 카드 한장 가져오기");
 
-                                        return saveGameToRedis(game)
-                                                .flatMap(success -> {
-                                                    if (success) {
-                                                        log.info("[Broken] Redis 저장 완료");
-                                                        SecretPlayerResponse secretPlayerResponse = SecretPlayerResponse.from(game.findPlayer(playerId).get());
-                                                        PublicPlayerResponse publicPlayerResponse = PublicPlayerResponse.from(game.findPlayer(playerId).get());
-                                                        PublicPlayerResponse publicTargetPlayerResponse = PublicPlayerResponse.from(game.findPlayer(targetPlayerId).get());
-                                                        TurnChangedResponse turnChangedResponse = TurnChangedResponse.of(game.getCurrentTurnPlayerId());
-                                                        UseBrokenCardResultDTO response = new UseBrokenCardResultDTO(
-                                                                turnChangedResponse,
-                                                                secretPlayerResponse,
-                                                                publicPlayerResponse,
-                                                                publicTargetPlayerResponse
-                                                        );
-                                                        return Mono.just(response);
-                                                    } else {
-                                                        log.error("[Broken] Redis 저장 실패");
-                                                        return Mono.error(new BusinessException(WsErrorStatus.INTERNAL_ERROR));
-                                                    }
-                                                })
-                                                .onErrorResume(e -> {
-                                                    if (e instanceof BusinessException) return Mono.error(e);
-                                                    log.error("[Broken] Redis 저장 중 예외 발생", e);
-                                                    return Mono.error(new WebSocketException(WsErrorStatus.INTERNAL_ERROR.getErrorReason()));
-                                                });
+                                        SecretPlayerResponse secretPlayerResponse = SecretPlayerResponse.from(game.findPlayer(playerId).get());
+                                        PublicPlayerResponse publicPlayerResponse = PublicPlayerResponse.from(game.findPlayer(playerId).get());
+                                        PublicPlayerResponse publicTargetPlayerResponse = PublicPlayerResponse.from(game.findPlayer(targetPlayerId).get());
 
-                                    } catch (Exception e) {
-                                        log.error("[Broken] 카드 처리 중 예외 발생", e);
-                                        return Mono.error(new WebSocketException(WsErrorStatus.INTERNAL_ERROR.getErrorReason()));
-                                    }
-                                })
-                                .onErrorResume(e -> {
-                                    if (e instanceof BusinessException) return Mono.error(e);
-                                    log.error("[Broken] 카드 조회 중 예외 발생", e);
-                                    return Mono.error(new WebSocketException(WsErrorStatus.INTERNAL_ERROR.getErrorReason()));
-                                });
-
+                                        boolean isRoundFinished = false;
+                                        if (game.nextTurnAndReturnRoundFinished()) {
+                                            isRoundFinished = true;
+                                        }
+                                        if(isRoundFinished) {
+                                            // 라운드 종료되면 RoundFinishedResponse 반환
+                                            // 사보타지가 이긴 경우만 존재
+                                            Map<Long, Integer> distributedGoldInfo = game.distributeGoldToSaboteur();
+                                            List<RoundFinishedPlayerDTO> playerList = distributedGoldInfo.entrySet().stream()
+                                                    .map(entry -> {
+                                                        long id = entry.getKey();
+                                                        int gainedGold = entry.getValue();
+                                                        return RoundFinishedPlayerDTO.of(id, player.getPlayerName(), player.getPlayerRole(), gainedGold);
+                                                    }).toList();
+                                            return setGameToRedis(gameId, game)
+                                                    .thenReturn(UseRepairCardResultDTO.forRoundFinishedResult(
+                                                            RoundFinishedResponse.of(PlayerRole.SABOTEUR, playerList),
+                                                            secretPlayerResponse,
+                                                            publicPlayerResponse,
+                                                            publicTargetPlayerResponse
+                                                    ));
+                                        } else {
+                                            // 라운드가 종료되지 않으면 TurnChangedResonse 반환
+                                            return setGameToRedis(gameId, game)
+                                                    .thenReturn(UseRepairCardResultDTO.forNormalResult(
+                                                            TurnChangedResponse.of(game.getCurrentTurnPlayerId()),
+                                                            secretPlayerResponse,
+                                                            publicPlayerResponse,
+                                                            publicTargetPlayerResponse
+                                                    ));
+                                        }
                     } catch (BusinessException e) {
                         return Mono.error(e);
                     } catch (Exception e) {

--- a/src/main/java/com/snowhite/server/service/GameService.java
+++ b/src/main/java/com/snowhite/server/service/GameService.java
@@ -669,7 +669,7 @@ public class GameService {
                 });
     }
 
-    public Mono<UseBrokenCardResultDTO> useBrokenCard(BrokenCardUseRequest request) {
+    public Mono<UseRepairCardResultDTO> useBrokenCard(BrokenCardUseRequest request) {
         Long gameId = request.gameId();
         Long playerId = request.playerId();
         int cardId = request.cardId();
@@ -688,9 +688,11 @@ public class GameService {
                         return findCardByCardId(cardId)
                                 .switchIfEmpty(Mono.error(new BusinessException(WsErrorStatus.BAD_REQUEST)))
                                 .flatMap(card -> {
+                                    log.info("[Broken] 카드 조회 성공 - cardId: {}", cardId);
                                     try {
-                                        log.info("[Broken] 카드 조회 성공 - cardId: {}", cardId);
+
                                         ActionCard brokenCard = (ActionCard) card;
+
                                         List<PlayerState> brokenStates = getBrokenStates(brokenCard.getActionCardType());
                                         log.info("[Broken] 부여할 상태 목록 - brokenStates: {}", brokenStates);
 
@@ -705,6 +707,8 @@ public class GameService {
                                         player.removeCard(cardId);
                                         log.info("[Broken] 상태 부여 및 카드 제거 완료 - playerId: {}, targetPlayerId: {}, cardId: {}",
                                                 playerId, targetPlayerId, cardId);
+
+                                        log.info("[Broken] targetPlayerState 전체 출력: {}", targetPlayer.getState());
                                         game.drawAndGiveCardToPlayer(playerId);
                                         log.info("[Broken] 카드 한장 가져오기");
 
@@ -743,6 +747,17 @@ public class GameService {
                                                             publicTargetPlayerResponse
                                                     ));
                                         }
+                                    } catch (Exception e) {
+                                        log.error("[Broken] 카드 처리 중 예외 발생", e);
+                                        return Mono.error(new WebSocketException(WsErrorStatus.INTERNAL_ERROR.getErrorReason()));
+                                    }
+                                })
+                                .onErrorResume(e -> {
+                                    if (e instanceof BusinessException) return Mono.error(e);
+                                    log.error("[Broken] 카드 조회 중 예외 발생", e);
+                                    return Mono.error(new WebSocketException(WsErrorStatus.INTERNAL_ERROR.getErrorReason()));
+                                });
+
                     } catch (BusinessException e) {
                         return Mono.error(e);
                     } catch (Exception e) {
@@ -756,4 +771,5 @@ public class GameService {
                     return Mono.error(new WebSocketException(WsErrorStatus.INTERNAL_ERROR.getErrorReason()));
                 });
     }
+
 }

--- a/src/main/java/com/snowhite/server/service/GameService.java
+++ b/src/main/java/com/snowhite/server/service/GameService.java
@@ -272,7 +272,8 @@ public class GameService {
                                             RoundFinishedResponse.of(PlayerRole.SABOTEUR, playerList),
                                             secretPlayerResponse,
                                             publicPlayerResponse,
-                                            fieldResponse
+                                            fieldResponse,
+                                            true
                                     ));
                         } else {
                             // 라운드가 종료되지 않으면 TurnChangedResonse 반환
@@ -315,7 +316,8 @@ public class GameService {
                         try {
                             Player player = findPlayerByPlayerId(game, playerId);
                             log.info("[Map] 플레이어 조회 성공 - playerId: {}", playerId);
-                            int destCarId = game.getDestCardIdAt(row, column);
+                            Integer destCarId = game.getDestCardIdAt(row, column);
+                            log.info("[Map] 목적지 카드 id: {}", destCarId);
                             if (destCarId == -1) {
                                 log.warn("[Map] 해당 위치에 카드가 없거나 사용 불가한 위치 - row: {}, column: {}", row, column);
                                 return Mono.error(new BusinessException(WsErrorStatus.BAD_REQUEST));
@@ -351,7 +353,9 @@ public class GameService {
                                         .thenReturn(UseMapCardResultDTO.forRoundFinishedResult(
                                                 RoundFinishedResponse.of(PlayerRole.SABOTEUR, playerList),
                                                 secretPlayerResponse,
-                                                publicPlayerResponse
+                                                publicPlayerResponse,
+                                                destCarId,
+                                                true
                                         ));
                             } else {
                                 // 라운드가 종료되지 않으면 TurnChangedResonse 반환
@@ -632,7 +636,8 @@ public class GameService {
                                                             RoundFinishedResponse.of(PlayerRole.SABOTEUR, playerList),
                                                             secretPlayerResponse,
                                                             publicPlayerResponse,
-                                                            publicTargetPlayerResponse
+                                                            publicTargetPlayerResponse,
+                                                            true
                                                     ));
                                         } else {
                                             // 라운드가 종료되지 않으면 TurnChangedResonse 반환
@@ -735,7 +740,8 @@ public class GameService {
                                                             RoundFinishedResponse.of(PlayerRole.SABOTEUR, playerList),
                                                             secretPlayerResponse,
                                                             publicPlayerResponse,
-                                                            publicTargetPlayerResponse
+                                                            publicTargetPlayerResponse,
+                                                            true
                                                     ));
                                         } else {
                                             // 라운드가 종료되지 않으면 TurnChangedResonse 반환

--- a/src/main/java/com/snowhite/server/websocket/dto/UseBrokenCardResultDTO.java
+++ b/src/main/java/com/snowhite/server/websocket/dto/UseBrokenCardResultDTO.java
@@ -10,7 +10,8 @@ public record UseBrokenCardResultDTO(
         RoundFinishedResponse roundFinishedResponse,
         SecretPlayerResponse secretPlayerResponse,
         PublicPlayerResponse publicPlayerResponse,
-        PublicPlayerResponse publicTargetPlayerResponse
+        PublicPlayerResponse publicTargetPlayerResponse,
+        boolean isRoundFinished
 
 ) {
     public static UseRepairCardResultDTO forNormalResult(
@@ -24,7 +25,8 @@ public record UseBrokenCardResultDTO(
                 null,
                 secretPlayerResponse,
                 publicPlayerResponse,
-                publicTargetPlayerResponse
+                publicTargetPlayerResponse,
+                false
         );
     }
 
@@ -32,14 +34,16 @@ public record UseBrokenCardResultDTO(
             RoundFinishedResponse roundFinishedResponse,
             SecretPlayerResponse secretPlayerResponse,
             PublicPlayerResponse publicPlayerResponse,
-            PublicPlayerResponse publicTargetPlayerResponse
+            PublicPlayerResponse publicTargetPlayerResponse,
+            boolean isRoundFinished
     ) {
         return new UseBrokenCardResultDTO(
                 null,
                 roundFinishedResponse,
                 secretPlayerResponse,
                 publicPlayerResponse,
-                publicTargetPlayerResponse
+                publicTargetPlayerResponse,
+                isRoundFinished
         );
     }
 }

--- a/src/main/java/com/snowhite/server/websocket/dto/UseBrokenCardResultDTO.java
+++ b/src/main/java/com/snowhite/server/websocket/dto/UseBrokenCardResultDTO.java
@@ -1,28 +1,42 @@
 package com.snowhite.server.websocket.dto;
 
-import com.snowhite.server.domain.enums.PlayerState;
 import com.snowhite.server.websocket.dto.response.PublicPlayerResponse;
+import com.snowhite.server.websocket.dto.response.RoundFinishedResponse;
 import com.snowhite.server.websocket.dto.response.SecretPlayerResponse;
 import com.snowhite.server.websocket.dto.response.TurnChangedResponse;
 
-import java.util.EnumSet;
-import java.util.List;
-
 public record UseBrokenCardResultDTO(
         TurnChangedResponse turnChangedResponse,
+        RoundFinishedResponse roundFinishedResponse,
         SecretPlayerResponse secretPlayerResponse,
         PublicPlayerResponse publicPlayerResponse,
         PublicPlayerResponse publicTargetPlayerResponse
 
 ) {
-    public static UseRepairCardDTO forNormalResult(
+    public static UseRepairCardResultDTO forNormalResult(
             TurnChangedResponse turnChangedResponse,
             SecretPlayerResponse secretPlayerResponse,
             PublicPlayerResponse publicPlayerResponse,
             PublicPlayerResponse publicTargetPlayerResponse
     ) {
-        return new UseRepairCardDTO(
+        return new UseRepairCardResultDTO(
                 turnChangedResponse,
+                null,
+                secretPlayerResponse,
+                publicPlayerResponse,
+                publicTargetPlayerResponse
+        );
+    }
+
+    public static UseBrokenCardResultDTO forRoundFinishedResult(
+            RoundFinishedResponse roundFinishedResponse,
+            SecretPlayerResponse secretPlayerResponse,
+            PublicPlayerResponse publicPlayerResponse,
+            PublicPlayerResponse publicTargetPlayerResponse
+    ) {
+        return new UseBrokenCardResultDTO(
+                null,
+                roundFinishedResponse,
                 secretPlayerResponse,
                 publicPlayerResponse,
                 publicTargetPlayerResponse

--- a/src/main/java/com/snowhite/server/websocket/dto/UseMapCardResultDTO.java
+++ b/src/main/java/com/snowhite/server/websocket/dto/UseMapCardResultDTO.java
@@ -2,28 +2,27 @@ package com.snowhite.server.websocket.dto;
 
 import com.snowhite.server.websocket.dto.response.*;
 
-import java.util.List;
 
 public record UseMapCardResultDTO(
         TurnChangedResponse turnChangedResponse,
         RoundFinishedResponse roundFinishedResponse,
         SecretPlayerResponse secretPlayerResponse,
         PublicPlayerResponse publicPlayerResponse,
-        int destCardId,
+        CardIdResponse cardIdResponse,
         boolean isRoundFinished
 ) {
     public static UseMapCardResultDTO forNormalResult(
             TurnChangedResponse turnChangedResponse,
             SecretPlayerResponse secretPlayerResponse,
             PublicPlayerResponse publicPlayerResponse,
-            Integer destCardId
+            CardIdResponse cardIdResponse
     ) {
         return new UseMapCardResultDTO(
                 turnChangedResponse,
                 null,
                 secretPlayerResponse,
                 publicPlayerResponse,
-                destCardId,
+                cardIdResponse,
                 false
         );
     }
@@ -31,7 +30,7 @@ public record UseMapCardResultDTO(
             RoundFinishedResponse roundFinishedResponse,
             SecretPlayerResponse secretPlayerResponse,
             PublicPlayerResponse publicPlayerResponse,
-            Integer destCardId,
+            CardIdResponse cardIdResponse,
             boolean isRoundFinished
     ) {
         return new UseMapCardResultDTO(
@@ -39,7 +38,7 @@ public record UseMapCardResultDTO(
                 roundFinishedResponse,
                 secretPlayerResponse,
                 publicPlayerResponse,
-                destCardId,
+                cardIdResponse,
                 isRoundFinished
         );
     }

--- a/src/main/java/com/snowhite/server/websocket/dto/UseMapCardResultDTO.java
+++ b/src/main/java/com/snowhite/server/websocket/dto/UseMapCardResultDTO.java
@@ -1,13 +1,12 @@
 package com.snowhite.server.websocket.dto;
 
-import com.snowhite.server.websocket.dto.response.PublicPlayerResponse;
-import com.snowhite.server.websocket.dto.response.SecretPlayerResponse;
-import com.snowhite.server.websocket.dto.response.TurnChangedResponse;
+import com.snowhite.server.websocket.dto.response.*;
 
 import java.util.List;
 
 public record UseMapCardResultDTO(
         TurnChangedResponse turnChangedResponse,
+        RoundFinishedResponse roundFinishedResponse,
         SecretPlayerResponse secretPlayerResponse,
         PublicPlayerResponse publicPlayerResponse
 ) {
@@ -18,6 +17,19 @@ public record UseMapCardResultDTO(
     ) {
         return new UseMapCardResultDTO(
                 turnChangedResponse,
+                null,
+                secretPlayerResponse,
+                publicPlayerResponse
+        );
+    }
+    public static UseMapCardResultDTO forRoundFinishedResult(
+            RoundFinishedResponse roundFinishedResponse,
+            SecretPlayerResponse secretPlayerResponse,
+            PublicPlayerResponse publicPlayerResponse
+    ) {
+        return new UseMapCardResultDTO(
+                null,
+                roundFinishedResponse,
                 secretPlayerResponse,
                 publicPlayerResponse
         );

--- a/src/main/java/com/snowhite/server/websocket/dto/UseMapCardResultDTO.java
+++ b/src/main/java/com/snowhite/server/websocket/dto/UseMapCardResultDTO.java
@@ -9,33 +9,38 @@ public record UseMapCardResultDTO(
         RoundFinishedResponse roundFinishedResponse,
         SecretPlayerResponse secretPlayerResponse,
         PublicPlayerResponse publicPlayerResponse,
-        Integer cardId
+        int destCardId,
+        boolean isRoundFinished
 ) {
     public static UseMapCardResultDTO forNormalResult(
             TurnChangedResponse turnChangedResponse,
             SecretPlayerResponse secretPlayerResponse,
             PublicPlayerResponse publicPlayerResponse,
-            int cardId
+            Integer destCardId
     ) {
         return new UseMapCardResultDTO(
                 turnChangedResponse,
                 null,
                 secretPlayerResponse,
                 publicPlayerResponse,
-                cardId
+                destCardId,
+                false
         );
     }
     public static UseMapCardResultDTO forRoundFinishedResult(
             RoundFinishedResponse roundFinishedResponse,
             SecretPlayerResponse secretPlayerResponse,
-            PublicPlayerResponse publicPlayerResponse
+            PublicPlayerResponse publicPlayerResponse,
+            Integer destCardId,
+            boolean isRoundFinished
     ) {
         return new UseMapCardResultDTO(
                 null,
                 roundFinishedResponse,
                 secretPlayerResponse,
                 publicPlayerResponse,
-                null
+                destCardId,
+                isRoundFinished
         );
     }
 }

--- a/src/main/java/com/snowhite/server/websocket/dto/UseMapCardResultDTO.java
+++ b/src/main/java/com/snowhite/server/websocket/dto/UseMapCardResultDTO.java
@@ -8,18 +8,21 @@ public record UseMapCardResultDTO(
         TurnChangedResponse turnChangedResponse,
         RoundFinishedResponse roundFinishedResponse,
         SecretPlayerResponse secretPlayerResponse,
-        PublicPlayerResponse publicPlayerResponse
+        PublicPlayerResponse publicPlayerResponse,
+        Integer cardId
 ) {
     public static UseMapCardResultDTO forNormalResult(
             TurnChangedResponse turnChangedResponse,
             SecretPlayerResponse secretPlayerResponse,
-            PublicPlayerResponse publicPlayerResponse
+            PublicPlayerResponse publicPlayerResponse,
+            int cardId
     ) {
         return new UseMapCardResultDTO(
                 turnChangedResponse,
                 null,
                 secretPlayerResponse,
-                publicPlayerResponse
+                publicPlayerResponse,
+                cardId
         );
     }
     public static UseMapCardResultDTO forRoundFinishedResult(
@@ -31,7 +34,8 @@ public record UseMapCardResultDTO(
                 null,
                 roundFinishedResponse,
                 secretPlayerResponse,
-                publicPlayerResponse
+                publicPlayerResponse,
+                null
         );
     }
 }

--- a/src/main/java/com/snowhite/server/websocket/dto/UseRepairCardDTO.java
+++ b/src/main/java/com/snowhite/server/websocket/dto/UseRepairCardDTO.java
@@ -2,6 +2,7 @@ package com.snowhite.server.websocket.dto;
 
 import com.snowhite.server.domain.enums.PlayerState;
 import com.snowhite.server.websocket.dto.response.PublicPlayerResponse;
+import com.snowhite.server.websocket.dto.response.RoundFinishedResponse;
 import com.snowhite.server.websocket.dto.response.SecretPlayerResponse;
 import com.snowhite.server.websocket.dto.response.TurnChangedResponse;
 
@@ -10,6 +11,7 @@ import java.util.List;
 
 public record UseRepairCardDTO(
         TurnChangedResponse turnChangedResponse,
+        RoundFinishedResponse roundFinishedResponse,
         SecretPlayerResponse secretPlayerResponse,
         PublicPlayerResponse publicPlayerResponse,
         PublicPlayerResponse publicTargetPlayerResponse
@@ -23,6 +25,22 @@ public record UseRepairCardDTO(
     ) {
         return new UseRepairCardDTO(
                 turnChangedResponse,
+                null,
+                secretPlayerResponse,
+                publicPlayerResponse,
+                publicTargetPlayerResponse
+        );
+    }
+
+    public static UseRepairCardDTO forRoundFinishedResult(
+            RoundFinishedResponse roundFinishedResponse,
+            SecretPlayerResponse secretPlayerResponse,
+            PublicPlayerResponse publicPlayerResponse,
+            PublicPlayerResponse publicTargetPlayerResponse
+    ) {
+        return new UseRepairCardDTO(
+                null,
+                roundFinishedResponse,
                 secretPlayerResponse,
                 publicPlayerResponse,
                 publicTargetPlayerResponse

--- a/src/main/java/com/snowhite/server/websocket/dto/UseRepairCardResultDTO.java
+++ b/src/main/java/com/snowhite/server/websocket/dto/UseRepairCardResultDTO.java
@@ -1,15 +1,11 @@
 package com.snowhite.server.websocket.dto;
 
-import com.snowhite.server.domain.enums.PlayerState;
 import com.snowhite.server.websocket.dto.response.PublicPlayerResponse;
 import com.snowhite.server.websocket.dto.response.RoundFinishedResponse;
 import com.snowhite.server.websocket.dto.response.SecretPlayerResponse;
 import com.snowhite.server.websocket.dto.response.TurnChangedResponse;
 
-import java.util.EnumSet;
-import java.util.List;
-
-public record UseRepairCardDTO(
+public record UseRepairCardResultDTO(
         TurnChangedResponse turnChangedResponse,
         RoundFinishedResponse roundFinishedResponse,
         SecretPlayerResponse secretPlayerResponse,
@@ -17,13 +13,13 @@ public record UseRepairCardDTO(
         PublicPlayerResponse publicTargetPlayerResponse
 
 ) {
-    public static UseRepairCardDTO forNormalResult(
+    public static UseRepairCardResultDTO forNormalResult(
             TurnChangedResponse turnChangedResponse,
             SecretPlayerResponse secretPlayerResponse,
             PublicPlayerResponse publicPlayerResponse,
             PublicPlayerResponse publicTargetPlayerResponse
     ) {
-        return new UseRepairCardDTO(
+        return new UseRepairCardResultDTO(
                 turnChangedResponse,
                 null,
                 secretPlayerResponse,
@@ -32,13 +28,13 @@ public record UseRepairCardDTO(
         );
     }
 
-    public static UseRepairCardDTO forRoundFinishedResult(
+    public static UseRepairCardResultDTO forRoundFinishedResult(
             RoundFinishedResponse roundFinishedResponse,
             SecretPlayerResponse secretPlayerResponse,
             PublicPlayerResponse publicPlayerResponse,
             PublicPlayerResponse publicTargetPlayerResponse
     ) {
-        return new UseRepairCardDTO(
+        return new UseRepairCardResultDTO(
                 null,
                 roundFinishedResponse,
                 secretPlayerResponse,

--- a/src/main/java/com/snowhite/server/websocket/dto/UseRepairCardResultDTO.java
+++ b/src/main/java/com/snowhite/server/websocket/dto/UseRepairCardResultDTO.java
@@ -10,7 +10,8 @@ public record UseRepairCardResultDTO(
         RoundFinishedResponse roundFinishedResponse,
         SecretPlayerResponse secretPlayerResponse,
         PublicPlayerResponse publicPlayerResponse,
-        PublicPlayerResponse publicTargetPlayerResponse
+        PublicPlayerResponse publicTargetPlayerResponse,
+        boolean isRoundFinished
 
 ) {
     public static UseRepairCardResultDTO forNormalResult(
@@ -24,7 +25,8 @@ public record UseRepairCardResultDTO(
                 null,
                 secretPlayerResponse,
                 publicPlayerResponse,
-                publicTargetPlayerResponse
+                publicTargetPlayerResponse,
+                false
         );
     }
 
@@ -32,14 +34,16 @@ public record UseRepairCardResultDTO(
             RoundFinishedResponse roundFinishedResponse,
             SecretPlayerResponse secretPlayerResponse,
             PublicPlayerResponse publicPlayerResponse,
-            PublicPlayerResponse publicTargetPlayerResponse
+            PublicPlayerResponse publicTargetPlayerResponse,
+            boolean isRoundFinished
     ) {
         return new UseRepairCardResultDTO(
                 null,
                 roundFinishedResponse,
                 secretPlayerResponse,
                 publicPlayerResponse,
-                publicTargetPlayerResponse
+                publicTargetPlayerResponse,
+                isRoundFinished
         );
     }
 }

--- a/src/main/java/com/snowhite/server/websocket/dto/UseRockfallCardResultDTO.java
+++ b/src/main/java/com/snowhite/server/websocket/dto/UseRockfallCardResultDTO.java
@@ -1,12 +1,10 @@
 package com.snowhite.server.websocket.dto;
 
-import com.snowhite.server.websocket.dto.response.FieldResponse;
-import com.snowhite.server.websocket.dto.response.PublicPlayerResponse;
-import com.snowhite.server.websocket.dto.response.SecretPlayerResponse;
-import com.snowhite.server.websocket.dto.response.TurnChangedResponse;
+import com.snowhite.server.websocket.dto.response.*;
 
 public record UseRockfallCardResultDTO(
     TurnChangedResponse turnChangedResponse,
+    RoundFinishedResponse roundFinishedResponse,
     SecretPlayerResponse secretPlayerResponse,
     PublicPlayerResponse publicPlayerResponse,
     FieldResponse fieldResponse
@@ -19,10 +17,25 @@ public record UseRockfallCardResultDTO(
     ) {
         return new UseRockfallCardResultDTO(
                 turnChangedResponse,
+                null,
                 secretPlayerResponse,
                 publicPlayerResponse,
                 fieldResponse
         );
     }
 
+    public static UseRockfallCardResultDTO forRoundFinishedResult(
+            RoundFinishedResponse roundFinishedResponse,
+            SecretPlayerResponse secretPlayerResponse,
+            PublicPlayerResponse publicPlayerResponse,
+            FieldResponse fieldResponse
+    ) {
+        return new UseRockfallCardResultDTO(
+                null,
+                roundFinishedResponse,
+                secretPlayerResponse,
+                publicPlayerResponse,
+                fieldResponse
+        );
+    }
 }

--- a/src/main/java/com/snowhite/server/websocket/dto/UseRockfallCardResultDTO.java
+++ b/src/main/java/com/snowhite/server/websocket/dto/UseRockfallCardResultDTO.java
@@ -7,7 +7,8 @@ public record UseRockfallCardResultDTO(
     RoundFinishedResponse roundFinishedResponse,
     SecretPlayerResponse secretPlayerResponse,
     PublicPlayerResponse publicPlayerResponse,
-    FieldResponse fieldResponse
+    FieldResponse fieldResponse,
+    boolean isRoundFinished
 ) {
     public static UseRockfallCardResultDTO forNormalResult(
             TurnChangedResponse turnChangedResponse,
@@ -20,7 +21,8 @@ public record UseRockfallCardResultDTO(
                 null,
                 secretPlayerResponse,
                 publicPlayerResponse,
-                fieldResponse
+                fieldResponse,
+                false
         );
     }
 
@@ -28,14 +30,16 @@ public record UseRockfallCardResultDTO(
             RoundFinishedResponse roundFinishedResponse,
             SecretPlayerResponse secretPlayerResponse,
             PublicPlayerResponse publicPlayerResponse,
-            FieldResponse fieldResponse
+            FieldResponse fieldResponse,
+            boolean isRoundFinished
     ) {
         return new UseRockfallCardResultDTO(
                 null,
                 roundFinishedResponse,
                 secretPlayerResponse,
                 publicPlayerResponse,
-                fieldResponse
+                fieldResponse,
+                isRoundFinished
         );
     }
 }

--- a/src/main/java/com/snowhite/server/websocket/dto/response/CardIdResponse.java
+++ b/src/main/java/com/snowhite/server/websocket/dto/response/CardIdResponse.java
@@ -1,0 +1,9 @@
+package com.snowhite.server.websocket.dto.response;
+
+public record CardIdResponse (
+        int cardId
+){
+    public static CardIdResponse of(int cardId) {
+        return new CardIdResponse(cardId);
+    }
+}

--- a/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
+++ b/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
@@ -236,17 +236,17 @@ public class GameWebSocketHandler implements WebSocketHandler {
         return gameService.useMapCard(request)
                 .flatMap(response -> {
                     Long gameId = request.gameId();
-                    log.info("dest card id in handler: {}", response.destCardId());
+                    log.info("dest card id in handler: {}", response.cardIdResponse());
                     if (response.isRoundFinished()) {
                         return sendMessage(session, "Player-Info", response.secretPlayerResponse())
-                                .then(sendMessage(session, "Dest-Card-Id", response.destCardId()))
+                                .then(sendMessage(session, "Dest-Card-Id", response.cardIdResponse()))
                                 .then(broadcastMessageToGame(gameId, "Player-Info-Changed", response.publicPlayerResponse()))
                                 .then(Mono.delay(Duration.ofSeconds(5)))
                                 // 역할 및 금덩이 분배 결과 공개
                                 .then(broadcastMessageToGame(gameId, "Round-Finished", response.roundFinishedResponse()));
                     } else {
                         return sendMessage(session, "Player-Info", response.secretPlayerResponse())
-                                .then(sendMessage(session, "Dest-Card-Id", response.destCardId()))
+                                .then(sendMessage(session, "Dest-Card-Id", response.cardIdResponse()))
                                 .then(broadcastMessageToGame(gameId, "Player-Info-Changed", response.publicPlayerResponse()))
                                 .then(broadcastMessageToGame(gameId, "Turn-Changed", response.turnChangedResponse()));
                     }

--- a/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
+++ b/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
@@ -211,10 +211,20 @@ public class GameWebSocketHandler implements WebSocketHandler {
         return gameService.useRockfallCard(request)
                 .flatMap(response -> {
                     Long gameId = request.gameId();
-                    return broadcastMessageToGame(gameId, "Field-Changed", response.fieldResponse())
-                            .then(sendMessage(session, "Player-Info", response.secretPlayerResponse()))
-                            .then(broadcastMessageToGame(gameId, "Player-Info-Changed", response.publicPlayerResponse()))
-                            .then(broadcastMessageToGame(gameId, "Turn-Changed", response.turnChangedResponse()));
+                    if (response.isRoundFinished()) {
+                        return broadcastMessageToGame(gameId, "Field-Changed", response.fieldResponse())
+                                .then(sendMessage(session, "Player-Info", response.secretPlayerResponse()))
+                                .then(broadcastMessageToGame(gameId, "Player-Info-Changed", response.publicPlayerResponse()))
+                                .then(Mono.delay(Duration.ofSeconds(5)))
+                                // 역할 및 금덩이 분배 결과 공개
+                                .then(broadcastMessageToGame(gameId, "Round-Finished", response.roundFinishedResponse()));
+                    } else {
+                        return broadcastMessageToGame(gameId, "Field-Changed", response.fieldResponse())
+                                .then(sendMessage(session, "Player-Info", response.secretPlayerResponse()))
+                                .then(broadcastMessageToGame(gameId, "Player-Info-Changed", response.publicPlayerResponse()))
+                                .then(broadcastMessageToGame(gameId, "Turn-Changed", response.turnChangedResponse()));
+                    }
+
                 })
                 .onErrorResume(e -> {
                     log.error("<rockfall card 처리 중 에러 발생>", e);
@@ -226,9 +236,21 @@ public class GameWebSocketHandler implements WebSocketHandler {
         return gameService.useMapCard(request)
                 .flatMap(response -> {
                     Long gameId = request.gameId();
-                    return sendMessage(session, "Player-Info", response.secretPlayerResponse())
-                            .then(broadcastMessageToGame(gameId, "Player-Info-Changed", response.publicPlayerResponse()))
-                            .then(broadcastMessageToGame(gameId, "Turn-Changed", response.turnChangedResponse()));
+                    log.info("dest card id in handler: {}", response.destCardId());
+                    if (response.isRoundFinished()) {
+                        return sendMessage(session, "Player-Info", response.secretPlayerResponse())
+                                .then(sendMessage(session, "Dest-Card-Id", response.destCardId()))
+                                .then(broadcastMessageToGame(gameId, "Player-Info-Changed", response.publicPlayerResponse()))
+                                .then(Mono.delay(Duration.ofSeconds(5)))
+                                // 역할 및 금덩이 분배 결과 공개
+                                .then(broadcastMessageToGame(gameId, "Round-Finished", response.roundFinishedResponse()));
+                    } else {
+                        return sendMessage(session, "Player-Info", response.secretPlayerResponse())
+                                .then(sendMessage(session, "Dest-Card-Id", response.destCardId()))
+                                .then(broadcastMessageToGame(gameId, "Player-Info-Changed", response.publicPlayerResponse()))
+                                .then(broadcastMessageToGame(gameId, "Turn-Changed", response.turnChangedResponse()));
+                    }
+
                 })
                 .onErrorResume(e -> {
                     log.error("<map card 처리 중 에러 발생>", e);
@@ -240,10 +262,20 @@ public class GameWebSocketHandler implements WebSocketHandler {
         return gameService.useRepairCard(request)
                 .flatMap(response -> {
                     Long gameId = request.gameId();
-                    return sendMessage(session, "Player-Info", response.secretPlayerResponse())
-                            .then(broadcastMessageToGame(gameId, "Player-Info-Changed", response.publicPlayerResponse()))
-                            .then(broadcastMessageToGame(gameId, "Player-Info-Changed", response.publicTargetPlayerResponse()))
-                            .then(broadcastMessageToGame(gameId, "Turn-Changed", response.turnChangedResponse()));
+                    if (response.isRoundFinished()) {
+                        return sendMessage(session, "Player-Info", response.secretPlayerResponse())
+                                .then(broadcastMessageToGame(gameId, "Player-Info-Changed", response.publicPlayerResponse()))
+                                .then(broadcastMessageToGame(gameId, "Player-Info-Changed", response.publicTargetPlayerResponse()))
+                                .then(Mono.delay(Duration.ofSeconds(5)))
+                                // 역할 및 금덩이 분배 결과 공개
+                                .then(broadcastMessageToGame(gameId, "Round-Finished", response.roundFinishedResponse()));
+                    } else {
+                        return sendMessage(session, "Player-Info", response.secretPlayerResponse())
+                                .then(broadcastMessageToGame(gameId, "Player-Info-Changed", response.publicPlayerResponse()))
+                                .then(broadcastMessageToGame(gameId, "Player-Info-Changed", response.publicTargetPlayerResponse()))
+                                .then(broadcastMessageToGame(gameId, "Turn-Changed", response.turnChangedResponse()));
+                    }
+
                 })
                 .onErrorResume(e -> {
                     log.error("<repair card 처리 중 에러 발생>", e);
@@ -258,7 +290,10 @@ public class GameWebSocketHandler implements WebSocketHandler {
                     return sendMessage(session, "Player-Info", response.secretPlayerResponse())
                             .then(broadcastMessageToGame(gameId, "Player-Info-Changed", response.publicPlayerResponse()))
                             .then(broadcastMessageToGame(gameId, "Player-Info-Changed", response.publicTargetPlayerResponse()))
-                            .then(broadcastMessageToGame(gameId, "Turn-Changed", response.turnChangedResponse()));
+                            .then(broadcastMessageToGame(gameId, "Turn-Changed", response.turnChangedResponse()))
+                            .then(Mono.delay(Duration.ofSeconds(5)))
+                            // 역할 및 금덩이 분배 결과 공개
+                            .then(broadcastMessageToGame(gameId, "Round-Finished", response.roundFinishedResponse()));
                 })
                 .onErrorResume(e -> {
                     log.error("<repair card 처리 중 에러 발생>", e);

--- a/src/test/java/com/snowhite/server/domain/session/GameTest.java
+++ b/src/test/java/com/snowhite/server/domain/session/GameTest.java
@@ -37,6 +37,11 @@ class GameTest {
     }
 
     @Test
+    void useRockfallCardSuccessTest() {
+
+    }
+
+    @Test
     void joinPlayerAndReturnRemain() {
         int remain1 = game.joinPlayerAndReturnRemain(1L);
         assertEquals(2, remain1);


### PR DESCRIPTION
## 📌 관련 이슈
- Jira: [SH-182]

## 📝 PR 요약
행동 카드 사용 후 플레이어 턴 변경하도록 수정
행동 카드 사용 후 라운드 종료 조건 검사
지도 카드 사용 후 목적지 card id도 응답에 포함
중복 메서드 하나로 통일

## ⚒️ 주요 변경 사항
- 행동 카드 사용 후 플레이어 턴 변경 확인
- 행동 카드 사용 후 라운드 종료 조건 확인
- handler에 라운드 종료 조건에 따라 응답 메시지 종류 다르도록 수정
- 지도 카드 사용 후 응답에 목적지 card id 포함
- 카드 사용 후 redis에 game 상태 반영을 위한 메서드 중복 제거

## 🧪 테스트 체크리스트
- [x] 행동 카드 사용 후 응답 확인 
- [x] 여러 조건에 따라 다른 응답 확인

## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?

[SH-182]: https://snowhite.atlassian.net/browse/SH-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ