### PR TITLE
[SH-183] 2라운드 시작 시 핸드 및 역할 미표시 해결

### DIFF
--- a/src/main/java/com/snowhite/server/service/GameService.java
+++ b/src/main/java/com/snowhite/server/service/GameService.java
@@ -144,8 +144,14 @@ public class GameService {
                         return deleteGameFromRedis(gameId)
                                 .thenReturn(NextRoundResultDTO.forFinishGame(PublicPlayerResponse.from(winner)));
                     }
+                    GameResponse gameResponse = GameResponse.from(game);
+                    List<SecretPlayerResponse> secretPlayerResponseList = game.getPlayers()
+                            .stream()
+                            .map(SecretPlayerResponse::from)
+                            .toList();
+
                     return setGameToRedis(gameId, game)
-                            .thenReturn(NextRoundResultDTO.forRoundStart(GameResponse.from(game)));
+                            .thenReturn(NextRoundResultDTO.forRoundStart(gameResponse, secretPlayerResponseList));
                 });
     }
 

--- a/src/main/java/com/snowhite/server/websocket/dto/NextRoundResultDTO.java
+++ b/src/main/java/com/snowhite/server/websocket/dto/NextRoundResultDTO.java
@@ -2,17 +2,21 @@ package com.snowhite.server.websocket.dto;
 
 import com.snowhite.server.websocket.dto.response.GameResponse;
 import com.snowhite.server.websocket.dto.response.PublicPlayerResponse;
+import com.snowhite.server.websocket.dto.response.SecretPlayerResponse;
+
+import java.util.List;
 
 public record NextRoundResultDTO(
         boolean isGameFinished,
         GameResponse gameResponse,
+        List<SecretPlayerResponse> secretPlayerResponseList,
         PublicPlayerResponse winnerPublicPlayerResponse
 ) {
-    public static NextRoundResultDTO forRoundStart(GameResponse gameResponse) {
-        return new NextRoundResultDTO(false, gameResponse, null);
+    public static NextRoundResultDTO forRoundStart(GameResponse gameResponse, List<SecretPlayerResponse> secretPlayerResponseList) {
+        return new NextRoundResultDTO(false, gameResponse, secretPlayerResponseList,null);
     }
 
     public static NextRoundResultDTO forFinishGame(PublicPlayerResponse publicPlayerResponse) {
-        return new NextRoundResultDTO(true, null, publicPlayerResponse);
+        return new NextRoundResultDTO(true, null, null, publicPlayerResponse);
     }
 }

--- a/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
+++ b/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
@@ -26,6 +26,7 @@ import reactor.core.publisher.Mono;
 import org.slf4j.Logger;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Component
@@ -185,7 +186,18 @@ public class GameWebSocketHandler implements WebSocketHandler {
                         return broadcastMessageToGame(gameId, "Game-Finished", nextRoundResultDTO.winnerPublicPlayerResponse());
                     }
                     // 게임을 끝나지 않고 다음 라운드 시작
-                    return broadcastMessageToGame(gameId, "Round-Started", nextRoundResultDTO.gameResponse());
+                    List<Mono<Void>> personalSends = nextRoundResultDTO.secretPlayerResponseList().stream()
+                            .map(secret -> {
+                                long playerId = secret.playerId();
+                                return reactiveRedisTemplateForSessionIds.opsForValue().get(GAME_SESSION_PREFIX + playerId)
+                                        .flatMap(sessionId -> {
+                                            WebSocketSession sessionToSend = sessionMap.get(sessionId);
+                                            return sendMessage(sessionToSend, "Player-Info", secret);
+                                        });
+                            })
+                            .toList();
+                    return broadcastMessageToGame(gameId, "Round-Started", nextRoundResultDTO.gameResponse())
+                            .then(Mono.when(personalSends));
                 });
     }
 


### PR DESCRIPTION
<!-- PR제목 예시: [SH-12] 로그인 기능 구현 -->
## 📌 관련 이슈
- Jira: [SH-183](https://snowhite.atlassian.net/browse/SH-183?atlOrigin=eyJpIjoiNmM3ZDU4MTE3ZjU2NDNlYmExOTY5ZjBhM2ZlYmRjNDYiLCJwIjoiaiJ9)

## 📝 PR 요약
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
- 2라운드 시작 시 Player-Info 전송

## ⚒️ 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- 각 session에 unicast로 secretPlayerInfo 전송 추가

## 💬 추가 사항


## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?

[SH-183]: https://snowhite.atlassian.net/browse/SH-183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ