### PR TITLE
[SH-182] 행동 카드 에러 메시지 형태 수정

### DIFF
--- a/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
+++ b/src/main/java/com/snowhite/server/websocket/handler/GameWebSocketHandler.java
@@ -240,7 +240,7 @@ public class GameWebSocketHandler implements WebSocketHandler {
                 })
                 .onErrorResume(e -> {
                     log.error("<rockfall card 처리 중 에러 발생>", e);
-                    return sendSimpleMessage(session, "error");
+                    return sendMessage(session, "error", "error");
                 });
     }
 
@@ -266,7 +266,7 @@ public class GameWebSocketHandler implements WebSocketHandler {
                 })
                 .onErrorResume(e -> {
                     log.error("<map card 처리 중 에러 발생>", e);
-                    return sendSimpleMessage(session, "error");
+                    return sendMessage(session, "error", "error");
                 });
     }
 
@@ -291,7 +291,7 @@ public class GameWebSocketHandler implements WebSocketHandler {
                 })
                 .onErrorResume(e -> {
                     log.error("<repair card 처리 중 에러 발생>", e);
-                    return sendSimpleMessage(session, "error");
+                    return sendMessage(session, "error", "error");
                 });
     }
 
@@ -309,7 +309,7 @@ public class GameWebSocketHandler implements WebSocketHandler {
                 })
                 .onErrorResume(e -> {
                     log.error("<repair card 처리 중 에러 발생>", e);
-                    return sendSimpleMessage(session, "error");
+                    return sendMessage(session, "error", "error");
                 });
     }
 
@@ -383,21 +383,6 @@ public class GameWebSocketHandler implements WebSocketHandler {
                             });
                 })
                 .then();
-    }
-
-    // 단순 문자열 전송
-    public Mono<Void> sendSimpleMessage(WebSocketSession session, String message) {
-
-        SimpleMessageResponse simpleMessageResponse = SimpleMessageResponse.of(message);
-        try {
-            String payload = objectMapper.writeValueAsString(simpleMessageResponse);
-            return session.send(Mono.just(
-                    session.textMessage(payload)
-            ));
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-            return Mono.error(e);   // TODO: 예외 처리
-        }
     }
 
     // type, payload 동시에 직렬화 후 메시지 전송


### PR DESCRIPTION
## 📌 관련 이슈
- Jira: [SH-182]

## 📝 PR 요약
행동 카드 에러에 대한 응답을 type, payload의 통일된 형식으로 전송

## ⚒️ 주요 변경 사항
- 행동 카드 에러에 대한 응답을 type, payload의 통일된 형식으로 전송
- handler의 sendMessage 사용하도록 변경

## 🧪 테스트 체크리스트
- [x] 로컬 테스트

## ✅ 체크리스트
- [x] 로컬에서 테스트를 완료했나요?
- [x] Assignees를 등록했나요?
- [x] Label을 지정했나요?

[SH-182]: https://snowhite.atlassian.net/browse/SH-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ